### PR TITLE
feat(pr-lint): support npm, yarn and pnpm

### DIFF
--- a/pr-lint/action.yml
+++ b/pr-lint/action.yml
@@ -47,8 +47,6 @@ runs:
     - name: Setup Node.js and run tests
       if: steps.detect-node.outputs.found == 'true'
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        cache: 'npm'
 
     - name: Install Node.js dependencies
       if: steps.detect-node.outputs.found == 'true'

--- a/pr-lint/action.yml
+++ b/pr-lint/action.yml
@@ -53,7 +53,7 @@ runs:
       shell: bash
       run: |
         if [ -f pnpm-lock.yaml ]; then
-          npm install -g pnpm # github actions runners doesn't come with pnpm
+          npm install -g pnpm # GitHub Actions runners don’t come with pnpm
           pnpm install
         elif [ -f yarn.lock ]; then
           yarn install

--- a/pr-lint/action.yml
+++ b/pr-lint/action.yml
@@ -53,7 +53,16 @@ runs:
     - name: Install Node.js dependencies
       if: steps.detect-node.outputs.found == 'true'
       shell: bash
-      run: npm ci
+      run: |
+        if [ -f package-lock.json ]; then
+          npm ci
+        fi
+        if [ -f yarn.lock ]; then
+          yarn install
+        fi
+        if [ -f pnpm-lock.yaml ]; then
+          pnpm install
+        fi
 
     # PHP tests if composer.json exists
     - name: Detect composer.json

--- a/pr-lint/action.yml
+++ b/pr-lint/action.yml
@@ -54,14 +54,15 @@ runs:
       if: steps.detect-node.outputs.found == 'true'
       shell: bash
       run: |
-        if [ -f package-lock.json ]; then
-          npm ci
-        fi
-        if [ -f yarn.lock ]; then
-          yarn install
-        fi
         if [ -f pnpm-lock.yaml ]; then
+          npm install -g pnpm # github actions runners doesn't come with pnpm
           pnpm install
+        elif [ -f yarn.lock ]; then
+          yarn install
+        elif [ -f package-lock.json ]; then
+          npm ci
+        else
+          echo "No supported lockfile found, skipping Node.js dependencies installation."
         fi
 
     # PHP tests if composer.json exists


### PR DESCRIPTION
This pull request updates the `pr-lint/action.yml` file to improve dependency installation logic by adding support for multiple package managers. 

Dependency installation improvements:

* [`pr-lint/action.yml`](diffhunk://#diff-b14a7c3a3c2d6f20a9283b6b4d427d58d55c37947b7e7babf51f5d5d7ee15b40L56-R65): Modified the `Install Node.js dependencies` step to check for the presence of `package-lock.json`, `yarn.lock`, and `pnpm-lock.yaml` files and run the appropriate package manager (`npm ci`, `yarn install`, or `pnpm install`) based on the detected lock file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved compatibility with multiple Node.js package managers (npm, yarn, pnpm) in the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->