### PR TITLE
fix: harden action scripts and version checks

### DIFF
--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -131,6 +131,14 @@ runs:
         fi
         echo "args=${args}" >> $GITHUB_OUTPUT
 
+    - name: Login to GitHub Container Registry
+      if: inputs.push == 'true'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
     - name: Set up Build Cache
       id: cache
       shell: bash
@@ -143,7 +151,8 @@ runs:
         fi
 
         # Registry cache configuration for better performance
-        registry_cache_ref="ghcr.io/${{ github.repository }}/cache:latest"
+        normalized_repo=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._\/-]/-/g')
+        registry_cache_ref="ghcr.io/${normalized_repo}/cache:latest"
         cache_from="$cache_from --cache-from type=registry,ref=$registry_cache_ref"
         cache_to="--cache-to type=registry,ref=$registry_cache_ref,mode=max"
 

--- a/docker-publish/action.yml
+++ b/docker-publish/action.yml
@@ -117,18 +117,24 @@ runs:
             "dockerhub")
               # Use docker manifest inspect for more reliable verification
               image_name="docker.io/${{ github.repository }}"
-              if ! docker manifest inspect "${image_name}:${{ steps.tags.outputs.version }}" > /dev/null 2>&1; then
-                echo "::error::Failed to verify Docker Hub publication"
-                success=false
-              fi
+              IFS=',' read -ra TAGS <<< "${{ steps.tags.outputs.all-tags }}"
+              for tag in "${TAGS[@]}"; do
+                if ! docker manifest inspect "${image_name}:${tag}" > /dev/null 2>&1; then
+                  echo "::error::Failed to verify Docker Hub publication for ${tag}"
+                  success=false
+                fi
+              done
               ;;
             "github")
               # Use docker manifest inspect for GitHub Container Registry
               image_name="ghcr.io/${{ github.repository }}"
-              if ! docker manifest inspect "${image_name}:${{ steps.tags.outputs.version }}" > /dev/null 2>&1; then
-                echo "::error::Failed to verify GitHub Packages publication"
-                success=false
-              fi
+              IFS=',' read -ra TAGS <<< "${{ steps.tags.outputs.all-tags }}"
+              for tag in "${TAGS[@]}"; do
+                if ! docker manifest inspect "${image_name}:${tag}" > /dev/null 2>&1; then
+                  echo "::error::Failed to verify GitHub Packages publication for ${tag}"
+                  success=false
+                fi
+              done
               ;;
           esac
         done

--- a/dotnet-version-detect/action.yml
+++ b/dotnet-version-detect/action.yml
@@ -51,7 +51,7 @@ runs:
           for csproj in $(find . -maxdepth 3 -name "*.csproj" | head -5); do
             if [ -f "$csproj" ]; then
               local target_framework
-              target_framework=$(grep -o '<TargetFramework[^>]*>net[0-9]\+\.[0-9]\+</TargetFramework>' "$csproj" | head -1 | sed -n 's/.*>net\([0-9]\+\.[0-9]\+\)<.*/\1/p')
+              target_framework=$(grep -oE '<TargetFrameworks?[^>]*>[^<]*</TargetFrameworks?>' "$csproj" | head -1 | grep -oE 'net[0-9]+\.[0-9]+' | head -1)
               if [ -n "$target_framework" ] && validate_dotnet_version "$target_framework"; then
                 echo "Found .NET version in $csproj: $target_framework" >&2
                 echo "$target_framework"
@@ -66,7 +66,7 @@ runs:
         get_directory_build_props_version() {
           if [ -f Directory.Build.props ]; then
             local version
-            version=$(grep -o '<TargetFramework[^>]*>net[0-9]\+\.[0-9]\+</TargetFramework>' Directory.Build.props | head -1 | sed -n 's/.*>net\([0-9]\+\.[0-9]\+\)<.*/\1/p')
+            version=$(grep -oE '<TargetFrameworks?[^>]*>[^<]*</TargetFrameworks?>' Directory.Build.props | head -1 | grep -oE 'net[0-9]+\.[0-9]+' | head -1)
             if [ -n "$version" ] && validate_dotnet_version "$version"; then
               echo "Found .NET version in Directory.Build.props: $version" >&2
               echo "$version"

--- a/php-laravel-phpunit/action.yml
+++ b/php-laravel-phpunit/action.yml
@@ -50,6 +50,7 @@ runs:
         default-version: ${{ inputs.php-version }}
 
     - uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # 2.34.1
+      id: setup-php
       with:
         php-version: ${{ steps.php-version.outputs.php-version }}
         extensions: ${{ inputs.extensions }}

--- a/python-lint-fix/action.yml
+++ b/python-lint-fix/action.yml
@@ -181,11 +181,11 @@ runs:
         rm /tmp/changed_files
 
     - name: Set Git Config for Fixes
-      if: steps.fix.outputs.fixed_count > 0
+      if: ${{ fromJSON(steps.fix.outputs.fixed_count) > 0 }}
       uses: ./set-git-config
 
     - name: Commit Fixes
-      if: steps.fix.outputs.fixed_count > 0
+      if: ${{ fromJSON(steps.fix.outputs.fixed_count) > 0 }}
       shell: bash
       run: |
         set -euo pipefail

--- a/python-version-detect-v2/action.yml
+++ b/python-version-detect-v2/action.yml
@@ -41,7 +41,7 @@ runs:
         get_pyproject_version() {
           if [ -f pyproject.toml ]; then
             local version
-            version=$(grep -E '^requires-python\s*=' pyproject.toml | sed -n 's/.*[">= ]*\([0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\).*/\1/p' | head -1)
+            version=$(grep -E '^\s*requires-python\s*=' pyproject.toml | sed -n 's/.*[">= ]*\([0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\).*/\1/p' | head -1)
             if [ -n "$version" ]; then
               echo "$version"
               return 0
@@ -93,7 +93,7 @@ runs:
         get_tox_version() {
           if [ -f tox.ini ]; then
             local version
-            version=$(grep -E '^basepython\s*=' tox.ini | sed -n 's/.*python\([0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\).*/\1/p' | head -1)
+            version=$(grep -E '^\s*basepython\s*=' tox.ini | sed -n 's/.*python\([0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?\).*/\1/p' | head -1)
             if [ -n "$version" ]; then
               echo "$version"
               return 0

--- a/terraform-lint-fix/action.yml
+++ b/terraform-lint-fix/action.yml
@@ -202,6 +202,10 @@ runs:
     - name: Set Git Config for Fixes
       if: steps.fix.outputs.fixed_count > 0
       uses: ./set-git-config
+      with:
+        token: ${{ github.token }}
+        username: ${{ github.actor }}
+        email: ${{ github.actor }}@users.noreply.github.com
 
     - name: Commit Fixes
       if: steps.fix.outputs.fixed_count > 0

--- a/version-file-parser/action.yml
+++ b/version-file-parser/action.yml
@@ -52,7 +52,8 @@ runs:
         # Function to validate version format
         validate_version() {
           local version=$1
-          if [[ $version =~ ${{ inputs.validation-regex }} ]]; then
+          local regex="${{ inputs.validation-regex }}"
+          if [[ $version =~ $regex ]]; then
             return 0
           fi
           return 1
@@ -72,7 +73,7 @@ runs:
         # Parse .tool-versions file
         if [ -f .tool-versions ]; then
           echo "Checking .tool-versions for ${{ inputs.tool-versions-key }}..." >&2
-          version=$(grep -E "^${{ inputs.tool-versions-key }}[[:space:]]" .tool-versions | sed 's/#.*//' | awk '{print $2}' | tr -d ' ' | tr -d '\n' || echo "")
+          version=$(awk -v key="${{ inputs.tool-versions-key }}" '$1==key {gsub(/#.*/, "", $2); print $2; exit}' .tool-versions | tr -d ' ' | tr -d '\n' || echo "")
           if [ -n "$version" ]; then
             version=$(clean_version "$version")
             if validate_version "$version"; then

--- a/version-validator/action.yml
+++ b/version-validator/action.yml
@@ -46,18 +46,22 @@ runs:
         language="${{ inputs.language }}"
 
         # Clean the version string
-        cleaned_version=$(echo "$input_version" | tr -d 'v' | tr -d ' ' | tr -d '\n' | tr -d '\r')
+        cleaned_version=$(echo "$input_version" | sed 's/^v//' | tr -d ' ' | tr -d '\n' | tr -d '\r')
 
         # Validate the version
         if [[ $cleaned_version =~ $regex ]]; then
-          echo "is-valid=true" >> $GITHUB_OUTPUT
-          echo "validated-version=$cleaned_version" >> $GITHUB_OUTPUT
-          echo "error-message=" >> $GITHUB_OUTPUT
+          {
+            echo "is-valid=true"
+            printf 'validated-version=%s\n' "$cleaned_version"
+            echo "error-message="
+          } >> "$GITHUB_OUTPUT"
           echo "✅ Valid $language version: $cleaned_version" >&2
         else
-          echo "is-valid=false" >> $GITHUB_OUTPUT
-          echo "validated-version=" >> $GITHUB_OUTPUT
           error_msg="Invalid $language version format: '$input_version' (cleaned: '$cleaned_version'). Expected pattern: $regex"
-          echo "error-message=$error_msg" >> $GITHUB_OUTPUT
+          {
+            echo "is-valid=false"
+            echo "validated-version="
+            printf 'error-message=%s\n' "$error_msg"
+          } >> "$GITHUB_OUTPUT"
           echo "❌ $error_msg" >&2
         fi


### PR DESCRIPTION
## Summary
- fix quoting for validation regex and parse tool-versions literally
- add git credentials for terraform lint fixer
- parse numeric outputs correctly in python lint fixer
- login to GHCR and normalize repo names for docker-build cache
- verify all tags in docker publish
- support multi-target frameworks for .NET detection
- add setup-php step id
- strip only leading `v` and escape outputs in version validator
- allow leading whitespace in python version detect v2

## Testing
- `pre-commit run --files docker-build/action.yml docker-publish/action.yml dotnet-version-detect/action.yml php-laravel-phpunit/action.yml python-lint-fix/action.yml python-version-detect-v2/action.yml terraform-lint-fix/action.yml version-file-parser/action.yml version-validator/action.yml` *(fails: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68862dd0ab70832f8132730394c3de4b