### PR TITLE
chore: update docs, vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "connectionId": "ivuorinen",
     "projectKey": "ivuorinen_actions"
   },
-  "sarif-viewer.connectToGithubCodeScanning": "on"
+  "sarif-viewer.connectToGithubCodeScanning": "on",
+  "makefile.configureOnOpen": false
 }

--- a/validate-inputs/README.md
+++ b/validate-inputs/README.md
@@ -35,6 +35,8 @@ Centralized Python-based input validation for GitHub Actions with PCRE regex sup
 | `image-quality`     | <p>Image quality percentage</p>                                                    | `false`  | `""`    |
 | `png-quality`       | <p>PNG quality percentage</p>                                                      | `false`  | `""`    |
 | `parallel-builds`   | <p>Number of parallel builds</p>                                                   | `false`  | `""`    |
+| `days-before-stale` | <p>Number of days before marking as stale</p>                                      | `false`  | `""`    |
+| `days-before-close` | <p>Number of days before closing stale items</p>                                   | `false`  | `""`    |
 | `pre-commit-config` | <p>Pre-commit configuration file path</p>                                          | `false`  | `""`    |
 | `base-branch`       | <p>Base branch name</p>                                                            | `false`  | `""`    |
 | `dry-run`           | <p>Dry run mode</p>                                                                | `false`  | `""`    |
@@ -222,6 +224,18 @@ This action is a `composite` action.
 
     parallel-builds:
     # Number of parallel builds
+    #
+    # Required: false
+    # Default: ""
+
+    days-before-stale:
+    # Number of days before marking as stale
+    #
+    # Required: false
+    # Default: ""
+
+    days-before-close:
+    # Number of days before closing stale items
     #
     # Required: false
     # Default: ""


### PR DESCRIPTION
This pull request introduces new configuration options for input validation in GitHub Actions and makes a small update to VSCode workspace settings. The most significant changes are the addition of two new parameters related to stale item management in the input validation documentation and configuration.

#### Input validation enhancements:
* Added `days-before-stale` and `days-before-close` parameters to the input validation documentation table in `validate-inputs/README.md`, allowing users to specify timeframes for marking and closing stale items.
* Documented the usage of `days-before-stale` and `days-before-close` in the YAML configuration section of `validate-inputs/README.md`.

#### Workspace configuration:
* Disabled automatic Makefile configuration on open by setting `"makefile.configureOnOpen": false` in `.vscode/settings.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional inputs: days-before-stale and days-before-close to customize staleness and auto-close timing. Defaults maintain existing behavior.

* **Documentation**
  * Updated action README with descriptions and usage examples for the new inputs.

* **Chores**
  * Adjusted workspace editor settings to disable automatic Makefile configuration; no impact on runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->