### PR TITLE
fix: support INPUT_ACTION_TYPE and INPUT_ACTION

### DIFF
--- a/npm-publish/README.md
+++ b/npm-publish/README.md
@@ -10,10 +10,10 @@ Publishes the package to the NPM registry with configurable scope and registry U
 
 | name              | description                            | required | default                                |
 |-------------------|----------------------------------------|----------|----------------------------------------|
+| `npm_token`       | <p>NPM token.</p>                      | `true`   | `""`                                   |
 | `registry-url`    | <p>Registry URL for publishing.</p>    | `false`  | `https://registry.npmjs.org/`          |
 | `scope`           | <p>Package scope to use.</p>           | `false`  | `@ivuorinen`                           |
 | `package-version` | <p>The version to publish.</p>         | `false`  | `${{ github.event.release.tag_name }}` |
-| `npm_token`       | <p>NPM token.</p>                      | `true`   | `""`                                   |
 | `token`           | <p>GitHub token for authentication</p> | `false`  | `""`                                   |
 
 ### Outputs
@@ -33,6 +33,12 @@ This action is a `composite` action.
 ```yaml
 - uses: ivuorinen/actions/npm-publish@main
   with:
+    npm_token:
+    # NPM token.
+    #
+    # Required: true
+    # Default: ""
+
     registry-url:
     # Registry URL for publishing.
     #
@@ -50,12 +56,6 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: ${{ github.event.release.tag_name }}
-
-    npm_token:
-    # NPM token.
-    #
-    # Required: true
-    # Default: ""
 
     token:
     # GitHub token for authentication

--- a/validate-inputs/README.md
+++ b/validate-inputs/README.md
@@ -10,7 +10,7 @@ Centralized Python-based input validation for GitHub Actions with PCRE regex sup
 
 | name                | description                                                                        | required | default |
 |---------------------|------------------------------------------------------------------------------------|----------|---------|
-| `action`            | <p>Action name to validate (alias for action-type)</p>                             | `true`   | `""`    |
+| `action`            | <p>Action name to validate (alias for action-type)</p>                             | `false`  | `""`    |
 | `action-type`       | <p>Type of action to validate (e.g., csharp-publish, docker-build, eslint-fix)</p> | `false`  | `""`    |
 | `rules-file`        | <p>Path to validation rules file</p>                                               | `false`  | `""`    |
 | `fail-on-error`     | <p>Whether to fail on validation errors</p>                                        | `false`  | `true`  |
@@ -81,7 +81,7 @@ This action is a `composite` action.
     action:
     # Action name to validate (alias for action-type)
     #
-    # Required: true
+    # Required: false
     # Default: ""
 
     action-type:

--- a/validate-inputs/action.yml
+++ b/validate-inputs/action.yml
@@ -13,7 +13,7 @@ branding:
 inputs:
   action:
     description: 'Action name to validate (alias for action-type)'
-    required: true
+    required: false
   action-type:
     description: 'Type of action to validate (e.g., csharp-publish, docker-build, eslint-fix)'
     required: false

--- a/validate-inputs/validator.py
+++ b/validate-inputs/validator.py
@@ -32,7 +32,7 @@ def collect_inputs() -> dict[str, str]:
     """
     inputs = {}
     for key, value in os.environ.items():
-        if key.startswith("INPUT_") and key != "INPUT_ACTION_TYPE":
+        if key.startswith("INPUT_") and key not in ("INPUT_ACTION_TYPE", "INPUT_ACTION"):
             input_name = key[6:].lower()
             inputs[input_name] = value
 
@@ -73,8 +73,11 @@ def write_output(status: str, action_type: str, **kwargs) -> None:
 
 def main() -> None:
     """Main validation entry point."""
-    # Get the action type from environment
-    action_type = os.environ.get("INPUT_ACTION_TYPE", "").strip()
+    # Get the action type from environment (check both INPUT_ACTION_TYPE and INPUT_ACTION)
+    action_type = (
+        os.environ.get("INPUT_ACTION_TYPE", "").strip()
+        or os.environ.get("INPUT_ACTION", "").strip()
+    )
     if not action_type:
         logger.error("::error::No action type provided")
         sys.exit(1)


### PR DESCRIPTION
This pull request updates documentation and input validation logic for two GitHub Actions: `npm-publish` and `validate-inputs`. The main changes clarify required inputs and improve flexibility in how the `validate-inputs` action determines the action type, making it easier to use and less error-prone.

**Documentation and input requirements updates:**

* In `npm-publish/README.md`, the documentation for the `npm_token` input is clarified and duplicate entries are removed to avoid confusion about required fields. [[1]](diffhunk://#diff-4943d16fb11608bda72cb58e3cb5a4993cbce1a301348c90e71b8f5acfcb63deR13-L16) [[2]](diffhunk://#diff-4943d16fb11608bda72cb58e3cb5a4993cbce1a301348c90e71b8f5acfcb63deR36-R41) [[3]](diffhunk://#diff-4943d16fb11608bda72cb58e3cb5a4993cbce1a301348c90e71b8f5acfcb63deL54-L59)
* In `validate-inputs/README.md` and `action.yml`, the `action` input is changed from required to optional, reflecting that either `action` or `action-type` can be used. [[1]](diffhunk://#diff-daf7b5a6133617b8dc3d1cb0821ff4946e4af2357e301d0cd87b79d74675fd05L13-R13) [[2]](diffhunk://#diff-daf7b5a6133617b8dc3d1cb0821ff4946e4af2357e301d0cd87b79d74675fd05L84-R84) [[3]](diffhunk://#diff-60308d5c5ad306140c005fd974e476ad9265525172050c92a37666dcc30f7c21L16-R16)

**Input validation logic improvements:**

* In `validate-inputs/validator.py`, the input collection logic now excludes both `INPUT_ACTION_TYPE` and `INPUT_ACTION` from the collected inputs to avoid redundancy and potential conflicts.
* The main validation entry point now checks both `INPUT_ACTION_TYPE` and `INPUT_ACTION` environment variables, using whichever is provided, to determine the action type. This increases flexibility for users of the action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated NPM publish action documentation to clarify npm_token input requirements and usage.

* **Bug Fixes**
  * Made the "action" input optional in validate-inputs action instead of required.
  * Improved validate-inputs action to accept action input in additional formats for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->