### PR TITLE
fix: test-actions security scan

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -235,8 +235,8 @@ jobs:
         uses: trufflesecurity/trufflehog@0f58ae7c5036094a1e3e750d18772af92821b503
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'pull_request' && github.event.repository.default_branch || '' }}
+          head: ${{ github.event_name == 'pull_request' && 'HEAD' || '' }}
           extra_args: --debug --only-verified
 
       - name: Scan shell scripts


### PR DESCRIPTION
This pull request makes a minor update to the TruffleHog scan configuration in the `.github/workflows/test-actions.yml` file. The change ensures that the `base` and `head` parameters are set only for pull request events, improving workflow flexibility.

* CI workflow improvement:
  * Updated the TruffleHog job to conditionally set the `base` and `head` parameters based on whether the event is a pull request, preventing unnecessary values for other event types. (`.github/workflows/test-actions.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Adjusted automated security scanning parameters to differentiate between pull request and push events, improving scan accuracy and preventing redundant reference operations in non-PR scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->