### PR TITLE
chore(deps): update internal action deps

### DIFF
--- a/ansible-lint-fix/action.yml
+++ b/ansible-lint-fix/action.yml
@@ -112,7 +112,7 @@ runs:
     - name: Cache Python Dependencies
       if: steps.check-files.outputs.files_found == 'true'
       id: cache-pip
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'pip'
         paths: '~/.cache/pip'
@@ -122,7 +122,7 @@ runs:
     - name: Install ansible-lint
       id: install-ansible-lint
       if: steps.check-files.outputs.files_found == 'true'
-      uses: ivuorinen/actions/common-retry@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-retry@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         command: 'pip install ansible-lint==6.22.1'
         max-retries: ${{ inputs.max-retries }}
@@ -162,7 +162,7 @@ runs:
     - name: Set Git Config for Fixes
       id: set-git-config
       if: steps.check-files.outputs.files_found == 'true'
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}

--- a/biome-check/action.yml
+++ b/biome-check/action.yml
@@ -44,7 +44,7 @@ runs:
   using: composite
   steps:
     - name: Validate Inputs (Centralized)
-      uses: ivuorinen/actions/validate-inputs@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/validate-inputs@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         action: biome-check
 
@@ -112,7 +112,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}
@@ -120,11 +120,11 @@ runs:
 
     - name: Node Setup
       id: node-setup
-      uses: ivuorinen/actions/node-setup@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/node-setup@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Cache Node Dependencies
       id: cache
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'npm'
         paths: 'node_modules'

--- a/biome-fix/action.yml
+++ b/biome-fix/action.yml
@@ -95,7 +95,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}
@@ -103,11 +103,11 @@ runs:
 
     - name: Node Setup
       id: node-setup
-      uses: ivuorinen/actions/node-setup@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/node-setup@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Cache Node Dependencies
       id: cache
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'npm'
         paths: 'node_modules'

--- a/codeql-analysis/action.yml
+++ b/codeql-analysis/action.yml
@@ -112,7 +112,7 @@ runs:
   using: composite
   steps:
     - name: Validate inputs
-      uses: ivuorinen/actions/validate-inputs@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/validate-inputs@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         action-type: codeql-analysis
         language: ${{ inputs.language }}

--- a/compress-images/action.yml
+++ b/compress-images/action.yml
@@ -143,7 +143,7 @@ runs:
         fi
     - name: Set Git Config
       id: set-git-config
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}

--- a/csharp-build/action.yml
+++ b/csharp-build/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Detect .NET SDK Version
       id: detect-dotnet-version
-      uses: ivuorinen/actions/dotnet-version-detect@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/dotnet-version-detect@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         default-version: "${{ inputs.dotnet-version || '7.0' }}"
 
@@ -61,7 +61,7 @@ runs:
 
     - name: Cache NuGet packages
       id: cache-nuget
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'nuget'
         paths: '~/.nuget/packages'
@@ -70,7 +70,7 @@ runs:
 
     - name: Restore Dependencies
       if: steps.cache-nuget.outputs.cache-hit != 'true'
-      uses: ivuorinen/actions/common-retry@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-retry@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         command: |
           echo "Restoring .NET dependencies..."

--- a/csharp-lint-check/action.yml
+++ b/csharp-lint-check/action.yml
@@ -66,7 +66,7 @@ runs:
 
     - name: Detect .NET SDK Version
       id: detect-dotnet-version
-      uses: ivuorinen/actions/dotnet-version-detect@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/dotnet-version-detect@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         default-version: ${{ inputs.dotnet-version || '7.0' }}
 

--- a/csharp-publish/action.yml
+++ b/csharp-publish/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/validate-inputs@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         action-type: 'csharp-publish'
         token: ${{ inputs.token }}
@@ -60,7 +60,7 @@ runs:
 
     - name: Detect .NET SDK Version
       id: detect-dotnet-version
-      uses: ivuorinen/actions/dotnet-version-detect@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/dotnet-version-detect@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         default-version: '7.0'
 
@@ -71,7 +71,7 @@ runs:
 
     - name: Cache NuGet packages
       id: cache-nuget
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'nuget'
         paths: '~/.nuget/packages'

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -147,7 +147,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/validate-inputs@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         action-type: 'docker-build'
         image-name: ${{ inputs.image-name }}

--- a/docker-publish/action.yml
+++ b/docker-publish/action.yml
@@ -170,7 +170,7 @@ runs:
 
     - name: Build Multi-Arch Docker Image
       id: build
-      uses: ivuorinen/actions/docker-build@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/docker-build@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         tag: ${{ steps.tags.outputs.all-tags }}
         architectures: ${{ inputs.platforms }}
@@ -185,7 +185,7 @@ runs:
     - name: Publish to Docker Hub
       id: publish-dockerhub
       if: contains(steps.dest.outputs.reg, 'dockerhub')
-      uses: ivuorinen/actions/docker-publish-hub@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/docker-publish-hub@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         tags: ${{ steps.tags.outputs.all-tags }}
         platforms: ${{ inputs.platforms }}
@@ -201,7 +201,7 @@ runs:
     - name: Publish to GitHub Packages
       id: publish-github
       if: contains(steps.dest.outputs.reg, 'github')
-      uses: ivuorinen/actions/docker-publish-gh@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/docker-publish-gh@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         tags: ${{ steps.tags.outputs.all-tags }}
         platforms: ${{ inputs.platforms }}

--- a/dotnet-version-detect/action.yml
+++ b/dotnet-version-detect/action.yml
@@ -58,7 +58,7 @@ runs:
 
     - name: Parse .NET Version
       id: parse-version
-      uses: ivuorinen/actions/version-file-parser@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/version-file-parser@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         language: 'dotnet'
         tool-versions-key: 'dotnet'

--- a/eslint-check/action.yml
+++ b/eslint-check/action.yml
@@ -176,11 +176,11 @@ runs:
 
     - name: Setup Node.js
       id: node-setup
-      uses: ivuorinen/actions/node-setup@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/node-setup@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Cache Node Dependencies
       id: cache
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'npm'
         paths: 'node_modules'

--- a/eslint-fix/action.yml
+++ b/eslint-fix/action.yml
@@ -44,7 +44,7 @@ runs:
   steps:
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/validate-inputs@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         action-type: 'eslint-fix'
         token: ${{ inputs.token }}
@@ -58,7 +58,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}
@@ -66,11 +66,11 @@ runs:
 
     - name: Node Setup
       id: node-setup
-      uses: ivuorinen/actions/node-setup@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/node-setup@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Cache Node Dependencies
       id: cache
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'npm'
         paths: 'node_modules'

--- a/go-build/action.yml
+++ b/go-build/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - name: Detect Go Version
       id: detect-go-version
-      uses: ivuorinen/actions/go-version-detect@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/go-version-detect@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         default-version: "${{ inputs.go-version || '1.21' }}"
 
@@ -66,7 +66,7 @@ runs:
 
     - name: Cache Go Dependencies
       id: cache-go
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'go'
         paths: '~/go/pkg/mod'
@@ -75,7 +75,7 @@ runs:
 
     - name: Download Dependencies
       if: steps.cache-go.outputs.cache-hit != 'true'
-      uses: ivuorinen/actions/common-retry@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-retry@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         command: |
           echo "Downloading Go dependencies..."

--- a/go-lint/action.yml
+++ b/go-lint/action.yml
@@ -218,7 +218,7 @@ runs:
     - name: Set up Cache
       id: cache
       if: inputs.cache == 'true'
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'go'
         paths: '~/.cache/golangci-lint,~/.cache/go-build'

--- a/go-version-detect/action.yml
+++ b/go-version-detect/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Parse Go Version
       id: parse-version
-      uses: ivuorinen/actions/version-file-parser@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/version-file-parser@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         language: 'go'
         tool-versions-key: 'golang'

--- a/node-setup/action.yml
+++ b/node-setup/action.yml
@@ -176,7 +176,7 @@ runs:
 
     - name: Parse Node.js Version
       id: version
-      uses: ivuorinen/actions/version-file-parser@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/version-file-parser@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         language: 'node'
         tool-versions-key: 'nodejs'
@@ -299,7 +299,7 @@ runs:
     - name: Cache Dependencies
       if: inputs.cache == 'true'
       id: deps-cache
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'npm'
         paths: '~/.npm,~/.yarn/cache,~/.pnpm-store,~/.bun/install/cache,node_modules'
@@ -359,7 +359,7 @@ runs:
 
     - name: Install Dependencies
       if: inputs.install == 'true' && steps.deps-cache.outputs.cache-hit != 'true'
-      uses: ivuorinen/actions/common-retry@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-retry@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         command: |
           package_manager="$PACKAGE_MANAGER"

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -101,7 +101,7 @@ runs:
         token: ${{ inputs.token || github.token }}
 
     - name: Setup Node.js
-      uses: ivuorinen/actions/node-setup@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/node-setup@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Authenticate NPM
       shell: sh

--- a/php-composer/action.yml
+++ b/php-composer/action.yml
@@ -79,7 +79,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/validate-inputs@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         action: php-composer
 
@@ -176,7 +176,7 @@ runs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'composer'
         paths: vendor,~/.composer/cache${{ inputs.cache-directories != "" && format(",{0}", inputs.cache-directories) || "" }}
@@ -196,7 +196,7 @@ runs:
         composer clear-cache
 
     - name: Install Dependencies
-      uses: ivuorinen/actions/common-retry@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-retry@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         command: composer install ${{ inputs.args }}
         max-retries: ${{ inputs.max-retries }}

--- a/php-laravel-phpunit/action.yml
+++ b/php-laravel-phpunit/action.yml
@@ -60,7 +60,7 @@ runs:
 
     - name: Detect PHP Version
       id: php-version
-      uses: ivuorinen/actions/php-version-detect@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/php-version-detect@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         default-version: ${{ inputs.php-version }}
 

--- a/php-tests/action.yml
+++ b/php-tests/action.yml
@@ -86,14 +86,14 @@ runs:
         token: ${{ inputs.token || github.token }}
 
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token != '' && inputs.token || github.token }}
         username: ${{ inputs.username }}
         email: ${{ inputs.email }}
 
     - name: Composer Install
-      uses: ivuorinen/actions/php-composer@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/php-composer@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Run PHPUnit Tests
       id: test

--- a/php-version-detect/action.yml
+++ b/php-version-detect/action.yml
@@ -67,7 +67,7 @@ runs:
 
     - name: Parse PHP Version
       id: parse-version
-      uses: ivuorinen/actions/version-file-parser@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/version-file-parser@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         language: 'php'
         tool-versions-key: 'php'

--- a/pr-lint/action.yml
+++ b/pr-lint/action.yml
@@ -40,7 +40,7 @@ runs:
   steps:
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/validate-inputs@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         action: pr-lint
         token: ${{ inputs.token }}
@@ -64,7 +64,7 @@ runs:
     #   ╰──────────────────────────────────────────────────────────╯
     - name: Setup Git Config
       id: git-config
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}
@@ -87,7 +87,7 @@ runs:
 
     - name: Setup Node.js environment
       if: steps.detect-node.outputs.found == 'true'
-      uses: ivuorinen/actions/node-setup@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/node-setup@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         install: true
         cache: true
@@ -106,7 +106,7 @@ runs:
     - name: Detect PHP Version
       if: steps.detect-php.outputs.found == 'true'
       id: php-version
-      uses: ivuorinen/actions/php-version-detect@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/php-version-detect@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Setup PHP
       if: steps.detect-php.outputs.found == 'true'
@@ -150,7 +150,7 @@ runs:
     - name: Detect Python Version
       if: steps.detect-python.outputs.found == 'true'
       id: python-version
-      uses: ivuorinen/actions/python-version-detect@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/python-version-detect@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Setup Python
       if: steps.detect-python.outputs.found == 'true'
@@ -181,7 +181,7 @@ runs:
     - name: Detect Go Version
       if: steps.detect-go.outputs.found == 'true'
       id: go-version
-      uses: ivuorinen/actions/go-version-detect@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/go-version-detect@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Setup Go
       if: steps.detect-go.outputs.found == 'true'

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/validate-inputs@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         action-type: 'pre-commit'
         token: ${{ inputs.token }}
@@ -58,7 +58,7 @@ runs:
         email: ${{ inputs.commit_email }}
         username: ${{ inputs.commit_user }}
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.commit_user }}

--- a/prettier-check/action.yml
+++ b/prettier-check/action.yml
@@ -202,11 +202,11 @@ runs:
 
     - name: Setup Node.js
       id: node-setup
-      uses: ivuorinen/actions/node-setup@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/node-setup@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Set up Cache
       id: cache
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       if: inputs.cache == 'true'
       with:
         type: 'npm'

--- a/prettier-fix/action.yml
+++ b/prettier-fix/action.yml
@@ -91,7 +91,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}
@@ -99,11 +99,11 @@ runs:
 
     - name: Node Setup
       id: node-setup
-      uses: ivuorinen/actions/node-setup@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/node-setup@a09e59aa7cb8246f584764d33505ff861b4c240c
 
     - name: Cache npm Dependencies
       id: cache-npm
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'npm'
         paths: 'node_modules'

--- a/python-lint-fix/action.yml
+++ b/python-lint-fix/action.yml
@@ -155,7 +155,7 @@ runs:
 
     - name: Detect Python Version
       id: python-version
-      uses: ivuorinen/actions/python-version-detect@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/python-version-detect@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         default-version: ${{ inputs.python-version }}
 
@@ -189,7 +189,7 @@ runs:
     - name: Cache Python Dependencies
       if: steps.check-files.outputs.result == 'found'
       id: cache-pip
-      uses: ivuorinen/actions/common-cache@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/common-cache@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         type: 'pip'
         paths: '~/.cache/pip'
@@ -325,7 +325,7 @@ runs:
 
     - name: Set Git Config for Fixes
       if: ${{ fromJSON(steps.fix.outputs.fixed_count) > 0 }}
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}

--- a/python-version-detect-v2/action.yml
+++ b/python-version-detect-v2/action.yml
@@ -72,7 +72,7 @@ runs:
 
     - name: Parse Python Version
       id: parse-version
-      uses: ivuorinen/actions/version-file-parser@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/version-file-parser@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         language: 'python'
         tool-versions-key: 'python'

--- a/python-version-detect/action.yml
+++ b/python-version-detect/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Parse Python Version
       id: parse-version
-      uses: ivuorinen/actions/version-file-parser@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/version-file-parser@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         language: 'python'
         tool-versions-key: 'python'

--- a/stale/action.yml
+++ b/stale/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/validate-inputs@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         action: 'stale'
         token: ${{ inputs.token || github.token }}

--- a/terraform-lint-fix/action.yml
+++ b/terraform-lint-fix/action.yml
@@ -78,7 +78,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/validate-inputs@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         action-type: 'terraform-lint-fix'
         token: ${{ inputs.token || github.token }}
@@ -270,7 +270,7 @@ runs:
 
     - name: Set Git Config for Fixes
       if: ${{ fromJSON(steps.fix.outputs.fixed_count) > 0 }}
-      uses: ivuorinen/actions/set-git-config@7061aafd35a2f21b57653e34f2b634b2a19334a9
+      uses: ivuorinen/actions/set-git-config@a09e59aa7cb8246f584764d33505ff861b4c240c
       with:
         token: ${{ inputs.token || github.token }}
         username: ${{ inputs.username }}


### PR DESCRIPTION
This pull request updates all references to reusable GitHub Actions in multiple workflow files to use a newer commit hash (`a09e59aa7cb8246f584764d33505ff861b4c240c`) instead of the previous one (`7061aafd35a2f21b57653e34f2b634b2a19334a9`). This ensures that all workflows consistently use the latest version of shared actions, which may include bug fixes, security updates, or new features.

The most important changes are:

**Centralized update of shared actions:**

* All usages of `ivuorinen/actions/common-cache`, `ivuorinen/actions/common-retry`, `ivuorinen/actions/set-git-config`, `ivuorinen/actions/node-setup`, `ivuorinen/actions/validate-inputs`, `ivuorinen/actions/version-file-parser`, `ivuorinen/actions/dotnet-version-detect`, `ivuorinen/actions/go-version-detect`, `ivuorinen/actions/docker-build`, `ivuorinen/actions/docker-publish-hub`, and `ivuorinen/actions/docker-publish-gh` across workflow files have been updated to the new commit hash. This affects caching, dependency installation, validation, and publishing steps for various languages and platforms. [[1]](diffhunk://#diff-29d14f63e8e2bccda34701dbb3c8843946efc8e7060dc14932e6650d44e98252L115-R115) [[2]](diffhunk://#diff-d1059fa6f347ea203d7570aa91a966372b549fb5c71dd3d83b8d4db7c232bfbeL47-R47) [[3]](diffhunk://#diff-71422302927777166be68f7c35e609cbe2c4d5bc73ee044e3a9af2850d86a2abL98-R110) [[4]](diffhunk://#diff-e219d1eac78ac47645c01f20f84695ee9d5e83232df177d89493166799da8cd7L115-R115) [[5]](diffhunk://#diff-b4ca036af55cd0a5cef425f25bacc09f094dc8659d1a60e1a69df6e28fc44107L146-R146) [[6]](diffhunk://#diff-c3c5b0e20f1b2e65bed99d6ef8e03ecdbd6df4f8255283a40f145ef10d390209L53-R53) [[7]](diffhunk://#diff-99cde55d7cefa820f0cb01d50c02927e72c3b2d76fab222cdd499b5cc7e1bfe9L69-R69) [[8]](diffhunk://#diff-3c82bf71c5559b35ede8f330ef8948b9ed517f920ad7815c0a4fab5550e90c70L54-R54) [[9]](diffhunk://#diff-d462aa6948ef2a3f62e8f193749ea6eddd4f80f0000f17259470d5d0a06ae35bL150-R150) [[10]](diffhunk://#diff-65edc991b0785f05dbb8acb28a5e17d95d0478f79d1f9cef2d8df8d2a00b7dc9L173-R173) [[11]](diffhunk://#diff-f29f9dd2264aad4a8f1974009a73a550327734c7434c2a22b3257aee56b19324L61-R61) [[12]](diffhunk://#diff-f4429d6358a6a73c14b0cf30b2b96f442d45afc8596e41c365a071efd3e8cf96L179-R183) [[13]](diffhunk://#diff-446fbdfbb950d47d7fd6b0948978d6871b3de799dcd141bd2b4568f527fea5ffL47-R47) [[14]](diffhunk://#diff-862d7bced8de90a6c79c85cafee50ae1156b441c22ee042d00d020ca4609257eL57-R57) [[15]](diffhunk://#diff-c38ff650d22521ddd1a24fbbf07f784a6e9583a75cdc3ddfe4dadf59c0aa802bL221-R221) [[16]](diffhunk://#diff-bcb4c5d66ec9fffdb4f01250bc7d42a33fae295e10db39e4a976c90a30204644L68-R68) [[17]](diffhunk://#diff-1c4f39754dfaa90a01f3e1757a517d8e20cbdee98dbd5dbc40d00771a12b74edL179-R179) [[18]](diffhunk://#diff-6109a8dbedc5762a599893233286d8887ec7285038cd020bfd5e4f5a8b7694c6L104-R104) [[19]](diffhunk://#diff-d2a4a5bf8b35324dce975774d44f519790b27bc0073b6e8f5e237945f6bad9d9L82-R82)

**Language-specific workflow improvements:**

* Node.js, Go, .NET, PHP, Docker, and C# build, lint, and publish workflows now all use the latest shared actions, ensuring consistency and potential improvements in dependency management, caching, and version detection. [[1]](diffhunk://#diff-c3c5b0e20f1b2e65bed99d6ef8e03ecdbd6df4f8255283a40f145ef10d390209L64-R64) [[2]](diffhunk://#diff-c3c5b0e20f1b2e65bed99d6ef8e03ecdbd6df4f8255283a40f145ef10d390209L73-R73) [[3]](diffhunk://#diff-3c82bf71c5559b35ede8f330ef8948b9ed517f920ad7815c0a4fab5550e90c70L63-R63) [[4]](diffhunk://#diff-3c82bf71c5559b35ede8f330ef8948b9ed517f920ad7815c0a4fab5550e90c70L74-R74) [[5]](diffhunk://#diff-862d7bced8de90a6c79c85cafee50ae1156b441c22ee042d00d020ca4609257eL69-R69) [[6]](diffhunk://#diff-862d7bced8de90a6c79c85cafee50ae1156b441c22ee042d00d020ca4609257eL78-R78) [[7]](diffhunk://#diff-1c4f39754dfaa90a01f3e1757a517d8e20cbdee98dbd5dbc40d00771a12b74edL302-R302) [[8]](diffhunk://#diff-1c4f39754dfaa90a01f3e1757a517d8e20cbdee98dbd5dbc40d00771a12b74edL362-R362)

**Validation and configuration steps:**

* All validation steps (`validate-inputs`) and git configuration steps (`set-git-config`) in affected workflows now reference the updated shared actions, which may include fixes for input validation and improved git setup procedures. [[1]](diffhunk://#diff-d1059fa6f347ea203d7570aa91a966372b549fb5c71dd3d83b8d4db7c232bfbeL115-R127) [[2]](diffhunk://#diff-446fbdfbb950d47d7fd6b0948978d6871b3de799dcd141bd2b4568f527fea5ffL61-R73) [[3]](diffhunk://#diff-b4ca036af55cd0a5cef425f25bacc09f094dc8659d1a60e1a69df6e28fc44107L146-R146)

**Version detection enhancements:**

* Actions responsible for detecting language/tool versions (`dotnet-version-detect`, `go-version-detect`, `version-file-parser`) have been updated, which could improve accuracy and reliability in selecting the correct versions for builds. [[1]](diffhunk://#diff-f29f9dd2264aad4a8f1974009a73a550327734c7434c2a22b3257aee56b19324L61-R61) [[2]](diffhunk://#diff-bcb4c5d66ec9fffdb4f01250bc7d42a33fae295e10db39e4a976c90a30204644L68-R68) [[3]](diffhunk://#diff-1c4f39754dfaa90a01f3e1757a517d8e20cbdee98dbd5dbc40d00771a12b74edL179-R179)

**Docker and publishing workflows:**

* Docker build and publish workflows now use the latest actions for building images and publishing to Docker Hub and GitHub Packages, which may include security or performance improvements. [[1]](diffhunk://#diff-65edc991b0785f05dbb8acb28a5e17d95d0478f79d1f9cef2d8df8d2a00b7dc9L173-R173) [[2]](diffhunk://#diff-65edc991b0785f05dbb8acb28a5e17d95d0478f79d1f9cef2d8df8d2a00b7dc9L188-R188) [[3]](diffhunk://#diff-65edc991b0785f05dbb8acb28a5e17d95d0478f79d1f9cef2d8df8d2a00b7dc9L204-R204)

These updates are important for maintaining workflow reliability and taking advantage of any improvements or fixes in the shared actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated versions of external workflow actions across all CI/CD pipelines to use latest stable releases, improving reliability and performance of build, lint, and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->