### PR TITLE
fix(validate-inputs): add logic to skip undefined empty

### DIFF
--- a/validate-inputs/validators/conventions.py
+++ b/validate-inputs/validators/conventions.py
@@ -285,7 +285,7 @@ class ConventionBasedValidator(BaseValidator):
         # Get conventions and overrides from rules
         conventions = self._rules.get("conventions", {})
         overrides = self._rules.get("overrides", {})
-        optional_inputs = self._rules.get("optional_inputs", [])
+        optional_inputs = self._rules.get("optional_inputs", {})
         required_inputs = self.get_required_inputs()
 
         # Validate each input
@@ -305,7 +305,9 @@ class ConventionBasedValidator(BaseValidator):
             # Skip validation for undefined inputs with empty values
             # This prevents auto-validation of irrelevant inputs from the
             # validate-inputs action's own input list
-            if not is_defined_input and (not value or value.strip() == ""):
+            if not is_defined_input and (
+                not value or (isinstance(value, str) and not value.strip())
+            ):
                 continue
 
             # Get validator type from overrides or conventions


### PR DESCRIPTION
This pull request improves the input validation logic in the `validate_inputs` method by ensuring that only relevant inputs are validated and that unnecessary validation is skipped for undefined or irrelevant inputs. This change helps prevent issues with auto-validation of inputs that are not part of the action's rules.

Input validation improvements:

* Skips validation for undefined inputs with empty values, preventing unnecessary validation of irrelevant inputs.
* Adds checks to determine if an input is defined in the action's rules by considering `required_inputs`, `optional_inputs`, `conventions`, and `overrides`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now correctly distinguishes optional vs required inputs based on rules, reducing false-required errors.
  * Inputs not defined in validation rules are skipped when their values are empty or whitespace, preventing unnecessary validation failures.
  * Consistent determination of input requirement status across validation checks, improving reliability of error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->