### PR TITLE
fix(set-git-config): remove credentials cleaning, it's automatic

### DIFF
--- a/set-git-config/action.yml
+++ b/set-git-config/action.yml
@@ -88,16 +88,6 @@ runs:
         GIT_USERNAME="$VALIDATED_GIT_USERNAME"
         GIT_EMAIL="$VALIDATED_GIT_EMAIL"
 
-        # Function to clean up Git config
-        cleanup_git_config() {
-          git config --local --unset-all "url.https://x-access-token:${TOKEN}@github.com/.insteadof" || true
-          git config --local --unset-all "user.name" || true
-          git config --local --unset-all "user.email" || true
-        }
-
-        # Set up trap to ensure cleanup on exit
-        trap cleanup_git_config EXIT
-
         # Store token in variable to avoid repeated exposure
         TOKEN="$GITHUB_TOKEN"
 


### PR DESCRIPTION
This pull request makes a small change to the `set-git-config/action.yml` file by removing the cleanup function and the associated exit trap that previously unset Git configuration settings at the end of the action's execution. This simplifies the action's script and removes automatic cleanup of Git config values.

* Removed the `cleanup_git_config` function and the `trap cleanup_git_config EXIT` line from the action script, so Git config values like `user.name`, `user.email`, and custom URL rewrites are no longer automatically unset at the end of the action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Git configuration applied by this action will now persist after execution, rather than being automatically reverted. Users should manage cleanup manually if needed for subsequent steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->