### PR TITLE
fix: ask_confirmation tty redirection

### DIFF
--- a/_tools/shared.sh
+++ b/_tools/shared.sh
@@ -153,7 +153,7 @@ prompt_confirmation() {
 
     # Use timeout command to limit read duration
     # shellcheck disable=SC2016
-    if response=$(timeout "$timeout_seconds" sh -c 'read -r r && echo "$r"' 2>/dev/null); then
+    if response=$(timeout "$timeout_seconds" sh -c 'read -r r </dev/tty && echo "$r"' 2>/dev/null); then
       : # read succeeded within timeout
     else
       printf '\n'


### PR DESCRIPTION
This pull request makes a minor adjustment to the way user input is read in the `prompt_confirmation()` function. The change ensures that the input is explicitly read from the terminal device (`/dev/tty`), which improves reliability in certain shell environments.

* Updated the `read` command in `prompt_confirmation()` to read from `/dev/tty`, ensuring user input is captured directly from the terminal. (`_tools/shared.sh`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive prompt reliability to maintain responsiveness when input is redirected during command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->