### PR TITLE
chore: update action references for release v2025.11.02

### DIFF
--- a/ansible-lint-fix/action.yml
+++ b/ansible-lint-fix/action.yml
@@ -112,7 +112,7 @@ runs:
     - name: Cache Python Dependencies
       if: steps.check-files.outputs.files_found == 'true'
       id: cache-pip
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'pip'
         paths: '~/.cache/pip'
@@ -122,7 +122,7 @@ runs:
     - name: Install ansible-lint
       id: install-ansible-lint
       if: steps.check-files.outputs.files_found == 'true'
-      uses: ivuorinen/actions/common-retry@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-retry@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         command: 'pip install ansible-lint==6.22.1'
         max-retries: ${{ inputs.max-retries }}
@@ -162,7 +162,7 @@ runs:
     - name: Set Git Config for Fixes
       id: set-git-config
       if: steps.check-files.outputs.files_found == 'true'
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}

--- a/biome-check/action.yml
+++ b/biome-check/action.yml
@@ -44,7 +44,7 @@ runs:
   using: composite
   steps:
     - name: Validate Inputs (Centralized)
-      uses: ivuorinen/actions/validate-inputs@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/validate-inputs@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         action-type: biome-check
 
@@ -112,7 +112,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}
@@ -120,11 +120,11 @@ runs:
 
     - name: Node Setup
       id: node-setup
-      uses: ivuorinen/actions/node-setup@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/node-setup@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Cache Node Dependencies
       id: cache
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'npm'
         paths: 'node_modules'

--- a/biome-fix/action.yml
+++ b/biome-fix/action.yml
@@ -95,7 +95,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}
@@ -103,11 +103,11 @@ runs:
 
     - name: Node Setup
       id: node-setup
-      uses: ivuorinen/actions/node-setup@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/node-setup@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Cache Node Dependencies
       id: cache
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'npm'
         paths: 'node_modules'

--- a/codeql-analysis/action.yml
+++ b/codeql-analysis/action.yml
@@ -112,7 +112,7 @@ runs:
   using: composite
   steps:
     - name: Validate inputs
-      uses: ivuorinen/actions/validate-inputs@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/validate-inputs@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         action-type: codeql-analysis
         language: ${{ inputs.language }}

--- a/compress-images/action.yml
+++ b/compress-images/action.yml
@@ -143,7 +143,7 @@ runs:
         fi
     - name: Set Git Config
       id: set-git-config
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}

--- a/csharp-build/action.yml
+++ b/csharp-build/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Detect .NET SDK Version
       id: detect-dotnet-version
-      uses: ivuorinen/actions/dotnet-version-detect@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/dotnet-version-detect@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         default-version: "${{ inputs.dotnet-version || '7.0' }}"
 
@@ -61,7 +61,7 @@ runs:
 
     - name: Cache NuGet packages
       id: cache-nuget
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'nuget'
         paths: '~/.nuget/packages'
@@ -70,7 +70,7 @@ runs:
 
     - name: Restore Dependencies
       if: steps.cache-nuget.outputs.cache-hit != 'true'
-      uses: ivuorinen/actions/common-retry@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-retry@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         command: |
           echo "Restoring .NET dependencies..."

--- a/csharp-lint-check/action.yml
+++ b/csharp-lint-check/action.yml
@@ -66,7 +66,7 @@ runs:
 
     - name: Detect .NET SDK Version
       id: detect-dotnet-version
-      uses: ivuorinen/actions/dotnet-version-detect@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/dotnet-version-detect@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         default-version: ${{ inputs.dotnet-version || '7.0' }}
 

--- a/csharp-publish/action.yml
+++ b/csharp-publish/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/validate-inputs@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         action-type: 'csharp-publish'
         token: ${{ inputs.token }}
@@ -60,7 +60,7 @@ runs:
 
     - name: Detect .NET SDK Version
       id: detect-dotnet-version
-      uses: ivuorinen/actions/dotnet-version-detect@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/dotnet-version-detect@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         default-version: '7.0'
 
@@ -71,7 +71,7 @@ runs:
 
     - name: Cache NuGet packages
       id: cache-nuget
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'nuget'
         paths: '~/.nuget/packages'

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -147,7 +147,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/validate-inputs@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         action-type: 'docker-build'
         image-name: ${{ inputs.image-name }}

--- a/docker-publish/action.yml
+++ b/docker-publish/action.yml
@@ -170,7 +170,7 @@ runs:
 
     - name: Build Multi-Arch Docker Image
       id: build
-      uses: ivuorinen/actions/docker-build@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/docker-build@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         tag: ${{ steps.tags.outputs.all-tags }}
         architectures: ${{ inputs.platforms }}
@@ -185,7 +185,7 @@ runs:
     - name: Publish to Docker Hub
       id: publish-dockerhub
       if: contains(steps.dest.outputs.reg, 'dockerhub')
-      uses: ivuorinen/actions/docker-publish-hub@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/docker-publish-hub@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         tags: ${{ steps.tags.outputs.all-tags }}
         platforms: ${{ inputs.platforms }}
@@ -201,7 +201,7 @@ runs:
     - name: Publish to GitHub Packages
       id: publish-github
       if: contains(steps.dest.outputs.reg, 'github')
-      uses: ivuorinen/actions/docker-publish-gh@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/docker-publish-gh@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         tags: ${{ steps.tags.outputs.all-tags }}
         platforms: ${{ inputs.platforms }}

--- a/dotnet-version-detect/action.yml
+++ b/dotnet-version-detect/action.yml
@@ -58,7 +58,7 @@ runs:
 
     - name: Parse .NET Version
       id: parse-version
-      uses: ivuorinen/actions/version-file-parser@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/version-file-parser@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         language: 'dotnet'
         tool-versions-key: 'dotnet'

--- a/eslint-check/action.yml
+++ b/eslint-check/action.yml
@@ -176,11 +176,11 @@ runs:
 
     - name: Setup Node.js
       id: node-setup
-      uses: ivuorinen/actions/node-setup@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/node-setup@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Cache Node Dependencies
       id: cache
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'npm'
         paths: 'node_modules'

--- a/eslint-fix/action.yml
+++ b/eslint-fix/action.yml
@@ -44,7 +44,7 @@ runs:
   steps:
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/validate-inputs@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         action-type: 'eslint-fix'
         token: ${{ inputs.token }}
@@ -58,7 +58,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}
@@ -66,11 +66,11 @@ runs:
 
     - name: Node Setup
       id: node-setup
-      uses: ivuorinen/actions/node-setup@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/node-setup@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Cache Node Dependencies
       id: cache
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'npm'
         paths: 'node_modules'

--- a/go-build/action.yml
+++ b/go-build/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - name: Detect Go Version
       id: detect-go-version
-      uses: ivuorinen/actions/go-version-detect@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/go-version-detect@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         default-version: "${{ inputs.go-version || '1.21' }}"
 
@@ -66,7 +66,7 @@ runs:
 
     - name: Cache Go Dependencies
       id: cache-go
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'go'
         paths: '~/go/pkg/mod'
@@ -75,7 +75,7 @@ runs:
 
     - name: Download Dependencies
       if: steps.cache-go.outputs.cache-hit != 'true'
-      uses: ivuorinen/actions/common-retry@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-retry@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         command: |
           echo "Downloading Go dependencies..."

--- a/go-lint/action.yml
+++ b/go-lint/action.yml
@@ -218,7 +218,7 @@ runs:
     - name: Set up Cache
       id: cache
       if: inputs.cache == 'true'
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'go'
         paths: '~/.cache/golangci-lint,~/.cache/go-build'

--- a/go-version-detect/action.yml
+++ b/go-version-detect/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Parse Go Version
       id: parse-version
-      uses: ivuorinen/actions/version-file-parser@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/version-file-parser@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         language: 'go'
         tool-versions-key: 'golang'

--- a/node-setup/action.yml
+++ b/node-setup/action.yml
@@ -176,7 +176,7 @@ runs:
 
     - name: Parse Node.js Version
       id: version
-      uses: ivuorinen/actions/version-file-parser@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/version-file-parser@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         language: 'node'
         tool-versions-key: 'nodejs'
@@ -300,7 +300,7 @@ runs:
     - name: Cache Dependencies
       if: inputs.cache == 'true'
       id: deps-cache
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'npm'
         paths: '~/.npm,~/.yarn/cache,~/.pnpm-store,~/.bun/install/cache,node_modules'
@@ -360,7 +360,7 @@ runs:
 
     - name: Install Dependencies
       if: inputs.install == 'true' && steps.deps-cache.outputs.cache-hit != 'true'
-      uses: ivuorinen/actions/common-retry@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-retry@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         command: |
           package_manager="$PACKAGE_MANAGER"

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -101,7 +101,7 @@ runs:
         token: ${{ inputs.token || github.token }}
 
     - name: Setup Node.js
-      uses: ivuorinen/actions/node-setup@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/node-setup@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Authenticate NPM
       shell: sh

--- a/php-composer/action.yml
+++ b/php-composer/action.yml
@@ -79,7 +79,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/validate-inputs@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         action-type: php-composer
 
@@ -176,7 +176,7 @@ runs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'composer'
         paths: vendor,~/.composer/cache${{ inputs.cache-directories != "" && format(",{0}", inputs.cache-directories) || "" }}
@@ -196,7 +196,7 @@ runs:
         composer clear-cache
 
     - name: Install Dependencies
-      uses: ivuorinen/actions/common-retry@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-retry@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         command: composer install ${{ inputs.args }}
         max-retries: ${{ inputs.max-retries }}

--- a/php-laravel-phpunit/action.yml
+++ b/php-laravel-phpunit/action.yml
@@ -60,7 +60,7 @@ runs:
 
     - name: Detect PHP Version
       id: php-version
-      uses: ivuorinen/actions/php-version-detect@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/php-version-detect@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         default-version: ${{ inputs.php-version }}
 

--- a/php-tests/action.yml
+++ b/php-tests/action.yml
@@ -86,14 +86,14 @@ runs:
         token: ${{ inputs.token || github.token }}
 
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token != '' && inputs.token || github.token }}
         username: ${{ inputs.username }}
         email: ${{ inputs.email }}
 
     - name: Composer Install
-      uses: ivuorinen/actions/php-composer@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/php-composer@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Run PHPUnit Tests
       id: test

--- a/php-version-detect/action.yml
+++ b/php-version-detect/action.yml
@@ -67,7 +67,7 @@ runs:
 
     - name: Parse PHP Version
       id: parse-version
-      uses: ivuorinen/actions/version-file-parser@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/version-file-parser@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         language: 'php'
         tool-versions-key: 'php'

--- a/pr-lint/action.yml
+++ b/pr-lint/action.yml
@@ -40,7 +40,7 @@ runs:
   steps:
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/validate-inputs@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         action-type: pr-lint
         token: ${{ inputs.token }}
@@ -64,7 +64,7 @@ runs:
     #   ╰──────────────────────────────────────────────────────────╯
     - name: Setup Git Config
       id: git-config
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token || github.token }}
         username: ${{ inputs.username }}
@@ -87,7 +87,7 @@ runs:
 
     - name: Setup Node.js environment
       if: steps.detect-node.outputs.found == 'true'
-      uses: ivuorinen/actions/node-setup@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/node-setup@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         install: true
         cache: true
@@ -106,7 +106,7 @@ runs:
     - name: Detect PHP Version
       if: steps.detect-php.outputs.found == 'true'
       id: php-version
-      uses: ivuorinen/actions/php-version-detect@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/php-version-detect@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Setup PHP
       if: steps.detect-php.outputs.found == 'true'
@@ -150,7 +150,7 @@ runs:
     - name: Detect Python Version
       if: steps.detect-python.outputs.found == 'true'
       id: python-version
-      uses: ivuorinen/actions/python-version-detect@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/python-version-detect@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Setup Python
       if: steps.detect-python.outputs.found == 'true'
@@ -181,7 +181,7 @@ runs:
     - name: Detect Go Version
       if: steps.detect-go.outputs.found == 'true'
       id: go-version
-      uses: ivuorinen/actions/go-version-detect@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/go-version-detect@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Setup Go
       if: steps.detect-go.outputs.found == 'true'

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -49,7 +49,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/validate-inputs@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         action-type: 'pre-commit'
         token: ${{ inputs.token }}
@@ -58,7 +58,7 @@ runs:
         email: ${{ inputs.commit_email }}
         username: ${{ inputs.commit_user }}
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.commit_user }}

--- a/prettier-check/action.yml
+++ b/prettier-check/action.yml
@@ -202,11 +202,11 @@ runs:
 
     - name: Setup Node.js
       id: node-setup
-      uses: ivuorinen/actions/node-setup@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/node-setup@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Set up Cache
       id: cache
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       if: inputs.cache == 'true'
       with:
         type: 'npm'

--- a/prettier-fix/action.yml
+++ b/prettier-fix/action.yml
@@ -91,7 +91,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: Set Git Config
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}
@@ -99,11 +99,11 @@ runs:
 
     - name: Node Setup
       id: node-setup
-      uses: ivuorinen/actions/node-setup@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/node-setup@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
 
     - name: Cache npm Dependencies
       id: cache-npm
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'npm'
         paths: 'node_modules'

--- a/python-lint-fix/action.yml
+++ b/python-lint-fix/action.yml
@@ -155,7 +155,7 @@ runs:
 
     - name: Detect Python Version
       id: python-version
-      uses: ivuorinen/actions/python-version-detect@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/python-version-detect@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         default-version: ${{ inputs.python-version }}
 
@@ -189,7 +189,7 @@ runs:
     - name: Cache Python Dependencies
       if: steps.check-files.outputs.result == 'found'
       id: cache-pip
-      uses: ivuorinen/actions/common-cache@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/common-cache@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         type: 'pip'
         paths: '~/.cache/pip'
@@ -325,7 +325,7 @@ runs:
 
     - name: Set Git Config for Fixes
       if: ${{ fromJSON(steps.fix.outputs.fixed_count) > 0 }}
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token }}
         username: ${{ inputs.username }}

--- a/python-version-detect-v2/action.yml
+++ b/python-version-detect-v2/action.yml
@@ -72,7 +72,7 @@ runs:
 
     - name: Parse Python Version
       id: parse-version
-      uses: ivuorinen/actions/version-file-parser@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/version-file-parser@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         language: 'python'
         tool-versions-key: 'python'

--- a/python-version-detect/action.yml
+++ b/python-version-detect/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Parse Python Version
       id: parse-version
-      uses: ivuorinen/actions/version-file-parser@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/version-file-parser@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         language: 'python'
         tool-versions-key: 'python'

--- a/stale/action.yml
+++ b/stale/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/validate-inputs@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         action-type: 'stale'
         token: ${{ inputs.token || github.token }}

--- a/terraform-lint-fix/action.yml
+++ b/terraform-lint-fix/action.yml
@@ -78,7 +78,7 @@ runs:
 
     - name: Validate Inputs
       id: validate
-      uses: ivuorinen/actions/validate-inputs@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/validate-inputs@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         action-type: 'terraform-lint-fix'
         token: ${{ inputs.token || github.token }}
@@ -270,7 +270,7 @@ runs:
 
     - name: Set Git Config for Fixes
       if: ${{ fromJSON(steps.fix.outputs.fixed_count) > 0 }}
-      uses: ivuorinen/actions/set-git-config@0fa9a68f07a1260b321f814202658a6089a43d42
+      uses: ivuorinen/actions/set-git-config@2f1c73dd8b23ffec17bb93ebd0f32e7a7c7546fc
       with:
         token: ${{ inputs.token || github.token }}
         username: ${{ inputs.username }}


### PR DESCRIPTION
This commit updates all internal action references to point to the current commit SHA in preparation for release v2025.11.02.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Action versions across all CI/CD workflows to latest stable releases for improved reliability and maintenance.
  * Enhanced caching configuration for dependency management to support multiple package manager lock files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->