### PR TITLE
fix(pr-lint): permissions

### DIFF
--- a/pr-lint/action.yml
+++ b/pr-lint/action.yml
@@ -37,9 +37,6 @@ outputs:
 
 runs:
   using: composite
-  permissions:
-    contents: write
-    pull-requests: write
   steps:
     - name: Validate Inputs
       id: validate
@@ -224,7 +221,7 @@ runs:
             contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref)
           }}
 
-        GITHUB_TOKEN: ${{ steps.git-config.outputs.token || inputs.token || secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.git-config.outputs.token || inputs.token || github.token }}
 
         # Apply linter fixes configuration
         #
@@ -304,7 +301,7 @@ runs:
       id: cpr
       if: env.APPLY_FIXES_IF_PR == 'true'
       with:
-        token: ${{ steps.git-config.outputs.token || inputs.token || secrets.GITHUB_TOKEN }}
+        token: ${{ steps.git-config.outputs.token || inputs.token || github.token }}
         commit-message: '[MegaLinter] Apply linters automatic fixes'
         title: '[MegaLinter] Apply linters automatic fixes'
         labels: bot


### PR DESCRIPTION
This pull request makes minor improvements to the `pr-lint/action.yml` workflow configuration, focusing on better handling of authentication tokens and branch references to ensure more reliable execution in different GitHub Actions contexts.

Authentication enhancements:
* Updated all token references to fall back to `github.token` if other sources are not available, improving robustness for authentication in steps requiring a token. [[1]](diffhunk://#diff-b14a7c3a3c2d6f20a9283b6b4d427d58d55c37947b7e7babf51f5d5d7ee15b40L223-R224) [[2]](diffhunk://#diff-b14a7c3a3c2d6f20a9283b6b4d427d58d55c37947b7e7babf51f5d5d7ee15b40L303-R304)

Branch reference handling:
* Added a more comprehensive branch reference assignment for the `actions/checkout` step to correctly check out the pull request's head branch in various event contexts.