### PR TITLE
fix: remove --verbose flag from PHPUnit command

### DIFF
--- a/php-tests/action.yml
+++ b/php-tests/action.yml
@@ -454,7 +454,7 @@ runs:
           phpunit_output=$(composer test 2>&1) || phpunit_exit_code=$?
         elif [ -f "vendor/bin/phpunit" ]; then
           echo "Running PHPUnit directly..."
-          phpunit_output=$(vendor/bin/phpunit --verbose 2>&1) || phpunit_exit_code=$?
+          phpunit_output=$(vendor/bin/phpunit 2>&1) || phpunit_exit_code=$?
         else
           echo "::error::PHPUnit not found. Ensure Composer dependencies are installed."
           exit 1


### PR DESCRIPTION
Root Cause:
- PHPUnit 10 and 11 (released 2024) removed the --verbose flag
- Running `vendor/bin/phpunit --verbose` results in "Unknown option" error
- Multiple projects (Debian packages, Laravel) encountered this in 2024

Evidence:
- GitHub issues #5647 in sebastianbergmann/phpunit
- Debian bug reports #1070508, #1070509, #1070510
- Laravel framework discussion #46672

Solution:
- Remove --verbose flag from line 457
- PHPUnit's default output is sufficient for parsing
- Output parsing logic (lines 465-486) works with standard format
- Tests confirm action designed for PHPUnit 10+ output format

Impact:
- Fixes compatibility with PHPUnit 10.x and 11.x
- Maintains backward compatibility (flag was informational only)
- No change to test result parsing behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified test output configuration to reduce verbosity in test result logs, making them more concise while maintaining all error handling and test execution behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->