### PR TITLE
fix: validate-inputs actions pip installation step

### DIFF
--- a/validate-inputs/action.yml
+++ b/validate-inputs/action.yml
@@ -213,6 +213,10 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Install Python dependencies
+      shell: bash
+      run: pip install pyyaml==6.0.3
+
     - name: Validate Action Inputs with Python
       id: validate
       shell: bash


### PR DESCRIPTION
This pull request adds a step to install the required Python dependency before running the validation script in the GitHub Action workflow.

- Workflow improvement:
  * Added a step to install the `pyyaml` Python package (version 6.0.3) in the `validate-inputs/action.yml` workflow to ensure dependencies are available before input validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the validation workflow to automatically install required Python dependencies before input validation runs. This prevents dependency-related failures, ensures the validator has needed prerequisites, and improves reliability and consistency of validation across composite runs and environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->