### PR TITLE
fix: add tag existence check to version-maintenance workflow

### DIFF
--- a/.github/workflows/version-maintenance.yml
+++ b/.github/workflows/version-maintenance.yml
@@ -55,6 +55,8 @@ jobs:
             printf '%s\n' "created=false" >> "$GITHUB_OUTPUT"
           else
             echo "Tag $MAJOR_VERSION not found, creating..."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
             git tag -a "$MAJOR_VERSION" -m "Major version $MAJOR_VERSION"
             git push origin "$MAJOR_VERSION"
             echo "Created and pushed tag $MAJOR_VERSION"


### PR DESCRIPTION
This pull request adds a new step to the `version-maintenance.yml` workflow to ensure that the major version Git tag exists before running the action versioning process. If the tag does not exist, it is created and pushed automatically.

Workflow automation:

* Added a new step named "Ensure Major Version Tag Exists" to check for the presence of the major version tag, and to create and push it if it does not exist (`.github/workflows/version-maintenance.yml`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-release check to ensure the major version tag exists and automatically create/push it if missing.
  * Improves reliability of release/version tagging so releases proceed smoothly when tags are absent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->