### PR TITLE
fix(validate-inputs): accept new stateless ghs_ installation token format

### DIFF
--- a/_tests/framework/test_action_validator_token.py
+++ b/_tests/framework/test_action_validator_token.py
@@ -1,0 +1,72 @@
+"""Tests for ActionValidator.validate_github_token.
+
+Exercises both stateful (40 chars) and stateless JWT (~520 chars) installation token
+formats. Per GitHub's 2026-04-27 rollout, ``${{ github.token }}`` expands to a
+``ghs_APPID_JWT`` token at workflow runtime, so the framework validator must accept it.
+
+See: https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header
+"""
+
+# pyright: reportMissingImports=false
+# pylint: disable=import-error,wrong-import-position
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from validation import ActionValidator
+
+
+class TestActionValidatorToken:
+    """Token-format tests for the framework ActionValidator class."""
+
+    def setup_method(self) -> None:
+        """Create a fresh ActionValidator per test."""
+        self.validator = ActionValidator()  # pylint: disable=attribute-defined-outside-init
+
+    def test_ghs_stateful_token(self) -> None:
+        """Stateful installation token: ghs_ + 36 alphanumeric (40 chars total)."""
+        ok, err = self.validator.validate_github_token("ghs_" + "a" * 36)
+        assert ok is True, err
+
+    def test_ghs_stateless_jwt_token(self) -> None:
+        """Stateless ghs_APPID_JWT format with two dots and underscores."""
+        jwt_header = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"
+        jwt_payload = "a" * 200
+        jwt_signature = "b" * 256
+        token = f"ghs_1234567_{jwt_header}.{jwt_payload}.{jwt_signature}"
+        ok, err = self.validator.validate_github_token(token)
+        assert ok is True, err
+
+    def test_ghs_length_boundaries(self) -> None:
+        """ghs_ body length must satisfy 36 <= len <= 1024 exactly."""
+        assert self.validator.validate_github_token("ghs_" + "a" * 36)[0] is True
+        assert self.validator.validate_github_token("ghs_" + "a" * 35)[0] is False
+        assert self.validator.validate_github_token("ghs_" + "a" * 1024)[0] is True
+        assert self.validator.validate_github_token("ghs_" + "a" * 1025)[0] is False
+
+    def test_ghs_invalid_chars_rejected(self) -> None:
+        """ghs_ body allows only [A-Za-z0-9._] — plus/slash/space rejected."""
+        for bad in ("ghs_" + "a" * 35 + "+", "ghs_" + "a" * 35 + "/", "ghs_" + "a" * 35 + " "):
+            ok, _ = self.validator.validate_github_token(bad)
+            assert ok is False, f"should reject: {bad!r}"
+
+    def test_ghp_classic_still_works(self) -> None:
+        """Classic PAT (ghp_ + 36 alphanumeric) is accepted."""
+        ok, _ = self.validator.validate_github_token("ghp_" + "a" * 36)
+        assert ok is True
+
+    def test_github_pat_fine_grained(self) -> None:
+        """Fine-grained PAT (github_pat_ + 50-255 chars) is accepted."""
+        ok, _ = self.validator.validate_github_token("github_pat_" + "a" * 71)
+        assert ok is True
+
+    def test_github_expression_accepted(self) -> None:
+        """``${{ github.token }}`` and similar expressions are accepted."""
+        ok, _ = self.validator.validate_github_token("${{ github.token }}")
+        assert ok is True
+
+    def test_wrong_prefix_rejected(self) -> None:
+        """Tokens with no recognized prefix are rejected."""
+        ok, _ = self.validator.validate_github_token("wrong_prefix_" + "a" * 36)
+        assert ok is False

--- a/_tests/framework/validation.py
+++ b/_tests/framework/validation.py
@@ -101,9 +101,15 @@ class ActionValidator:
 
         return (
             False,
-            "Invalid token format. Expected: gh[efpousr]_* (36 chars), "
-            "github_pat_[A-Za-z0-9_]* (50-255 chars), "
-            "ghs_* (40 chars stateful or ~520 chars stateless JWT), or npm_* (40+ chars)",
+            "Invalid token format. Expected one of: "
+            "gh[efpousr]_[a-zA-Z0-9]{36} (40 chars total — ghp/gho/ghu/ghs/ghr/ghe), "
+            "ghs_[A-Za-z0-9._]{36,1024} (40-1028 chars total — installation; "
+            "stateful or stateless JWT), "
+            "github_pat_[A-Za-z0-9_]{50,255} (fine-grained PAT), "
+            "npm_[a-zA-Z0-9]{40,} (NPM classic), "
+            "a ${{ ... }} expression (e.g. ${{ github.token }}, "
+            "${{ secrets.GITHUB_TOKEN }}), "
+            "or a $VAR env-var reference",
         )
 
     def validate_namespace_with_lookahead(self, namespace: str) -> tuple[bool, str]:

--- a/_tests/framework/validation.py
+++ b/_tests/framework/validation.py
@@ -39,10 +39,12 @@ class ActionValidator:
 
     # Standardized token patterns (resolved GitHub documentation discrepancies)
     # Fine-grained PATs are 50-255 characters with underscores (github_pat_[A-Za-z0-9_]{50,255})
+    # Installation tokens (ghs_) have two formats: stateful (40 chars) and
+    # stateless JWT (~520 chars, dots+underscores) — see GitHub's 2026-04-27 rollout.
     TOKEN_PATTERNS = {
         "classic": r"^gh[efpousr]_[a-zA-Z0-9]{36}$",
         "fine_grained": r"^github_pat_[A-Za-z0-9_]{50,255}$",  # 50-255 chars with underscores
-        "installation": r"^ghs_[a-zA-Z0-9]{36}$",
+        "installation": r"^ghs_[A-Za-z0-9._]{36,1024}$",
         "npm_classic": r"^npm_[a-zA-Z0-9]{40,}$",  # NPM classic tokens
     }
 
@@ -100,7 +102,8 @@ class ActionValidator:
         return (
             False,
             "Invalid token format. Expected: gh[efpousr]_* (36 chars), "
-            "github_pat_[A-Za-z0-9_]* (50-255 chars), ghs_* (36 chars), or npm_* (40+ chars)",
+            "github_pat_[A-Za-z0-9_]* (50-255 chars), "
+            "ghs_* (40 chars stateful or ~520 chars stateless JWT), or npm_* (40+ chars)",
         )
 
     def validate_namespace_with_lookahead(self, namespace: str) -> tuple[bool, str]:

--- a/_tests/shared/test_token_regex.py
+++ b/_tests/shared/test_token_regex.py
@@ -1,0 +1,105 @@
+"""Tests for ValidationCore.validate_github_token.
+
+Exercises both stateful (40 chars) and stateless JWT (~520 chars) installation token
+formats. Per GitHub's 2026-04-27 rollout, ``${{ github.token }}`` expands to a
+``ghs_APPID_JWT`` token at workflow runtime, so the test framework must accept it.
+
+See: https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header
+"""
+
+# pyright: reportMissingImports=false
+# pylint: disable=import-error,wrong-import-position
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from validation_core import ValidationCore
+
+
+class TestValidationCoreToken:
+    """Token-format tests for the shared ValidationCore class."""
+
+    def setup_method(self) -> None:
+        """Create a fresh ValidationCore per test."""
+        self.validator = ValidationCore()  # pylint: disable=attribute-defined-outside-init
+
+    def test_ghs_stateful_token(self) -> None:
+        """Stateful installation token: ghs_ + 36 alphanumeric (40 chars total)."""
+        ok, err = self.validator.validate_github_token("ghs_" + "a" * 36)
+        assert ok is True, err
+
+    def test_ghs_stateless_jwt_token(self) -> None:
+        """Stateless ghs_APPID_JWT format with two dots and underscores."""
+        jwt_header = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"
+        jwt_payload = "a" * 200
+        jwt_signature = "b" * 256
+        token = f"ghs_1234567_{jwt_header}.{jwt_payload}.{jwt_signature}"
+        ok, err = self.validator.validate_github_token(token)
+        assert ok is True, err
+
+    def test_ghs_minimum_body_length(self) -> None:
+        """Body of exactly 36 chars (regex minimum) is accepted."""
+        ok, _ = self.validator.validate_github_token("ghs_" + "a" * 36)
+        assert ok is True
+
+    def test_ghs_below_minimum_rejected(self) -> None:
+        """Body of 35 chars (one below minimum) is rejected."""
+        ok, _ = self.validator.validate_github_token("ghs_" + "a" * 35)
+        assert ok is False
+
+    def test_ghs_upper_bound_accepted(self) -> None:
+        """Body of exactly 1024 chars (regex upper bound) is accepted."""
+        ok, _ = self.validator.validate_github_token("ghs_" + "a" * 1024)
+        assert ok is True
+
+    def test_ghs_over_upper_bound_rejected(self) -> None:
+        """Body of 1025 chars (one over upper bound) is rejected."""
+        ok, _ = self.validator.validate_github_token("ghs_" + "a" * 1025)
+        assert ok is False
+
+    def test_ghs_invalid_chars_rejected(self) -> None:
+        """ghs_ body allows only [A-Za-z0-9._] — plus/slash/space rejected."""
+        for bad in ("ghs_" + "a" * 35 + "+", "ghs_" + "a" * 35 + "/", "ghs_" + "a" * 35 + " "):
+            ok, _ = self.validator.validate_github_token(bad)
+            assert ok is False, f"should reject: {bad!r}"
+
+    def test_ghp_classic_still_works(self) -> None:
+        """Classic PAT (ghp_ + 36 alphanumeric) is accepted."""
+        ok, _ = self.validator.validate_github_token("ghp_" + "a" * 36)
+        assert ok is True
+
+    def test_github_pat_fine_grained(self) -> None:
+        """Fine-grained PAT (github_pat_ + 50-255 chars) is accepted at min and inside range."""
+        ok, _ = self.validator.validate_github_token("github_pat_" + "a" * 50)
+        assert ok is True
+        ok, _ = self.validator.validate_github_token("github_pat_" + "a" * 71)
+        assert ok is True
+
+    def test_empty_optional(self) -> None:
+        """Empty token with required=False returns (True, '')."""
+        ok, err = self.validator.validate_github_token("")
+        assert ok is True
+        assert err == ""
+
+    def test_empty_required(self) -> None:
+        """Empty token with required=True returns (False, '...required...')."""
+        ok, err = self.validator.validate_github_token("", required=True)
+        assert ok is False
+        assert "required" in err.lower()
+
+    def test_github_expression_accepted(self) -> None:
+        """``${{ github.token }}`` and similar expressions are accepted."""
+        for expr in ("${{ github.token }}", "${{ secrets.GITHUB_TOKEN }}"):
+            ok, _ = self.validator.validate_github_token(expr)
+            assert ok is True
+
+    def test_env_var_reference_accepted(self) -> None:
+        """``$GITHUB_TOKEN`` style references are accepted."""
+        ok, _ = self.validator.validate_github_token("$GITHUB_TOKEN")
+        assert ok is True
+
+    def test_wrong_prefix_rejected(self) -> None:
+        """Tokens with no recognized prefix are rejected."""
+        ok, _ = self.validator.validate_github_token("wrong_prefix_" + "a" * 36)
+        assert ok is False

--- a/_tests/shared/validation_core.py
+++ b/_tests/shared/validation_core.py
@@ -33,11 +33,13 @@ class ValidationCore:
     """Core validation functionality with standardized patterns and functions."""
 
     # Standardized token patterns - resolved based on GitHub documentation
-    # Fine-grained tokens are 50-255 characters with underscores
+    # Fine-grained tokens are 50-255 characters with underscores.
+    # Installation tokens (ghs_) have two formats: stateful (40 chars) and
+    # stateless JWT (~520 chars, dots+underscores) — GitHub 2026-04-27 rollout.
     TOKEN_PATTERNS = {
         "classic": r"^gh[efpousr]_[a-zA-Z0-9]{36}$",
         "fine_grained": r"^github_pat_[A-Za-z0-9_]{50,255}$",  # 50-255 chars with underscores
-        "installation": r"^ghs_[a-zA-Z0-9]{36}$",
+        "installation": r"^ghs_[A-Za-z0-9._]{36,1024}$",
         "npm_classic": r"^npm_[a-zA-Z0-9]{40,}$",  # NPM classic tokens
     }
 
@@ -113,7 +115,8 @@ class ValidationCore:
         return (
             False,
             "Invalid token format. Expected: gh[efpousr]_* (36 chars), "
-            "github_pat_[A-Za-z0-9_]* (50-255 chars), ghs_* (36 chars), or npm_* (40+ chars)",
+            "github_pat_[A-Za-z0-9_]* (50-255 chars), "
+            "ghs_* (40 chars stateful or ~520 chars stateless JWT), or npm_* (40+ chars)",
         )
 
     def validate_namespace_with_lookahead(self, namespace: str) -> tuple[bool, str]:

--- a/_tests/shared/validation_core.py
+++ b/_tests/shared/validation_core.py
@@ -114,9 +114,15 @@ class ValidationCore:
 
         return (
             False,
-            "Invalid token format. Expected: gh[efpousr]_* (36 chars), "
-            "github_pat_[A-Za-z0-9_]* (50-255 chars), "
-            "ghs_* (40 chars stateful or ~520 chars stateless JWT), or npm_* (40+ chars)",
+            "Invalid token format. Expected one of: "
+            "gh[efpousr]_[a-zA-Z0-9]{36} (40 chars total — ghp/gho/ghu/ghs/ghr/ghe), "
+            "ghs_[A-Za-z0-9._]{36,1024} (40-1028 chars total — installation; "
+            "stateful or stateless JWT), "
+            "github_pat_[A-Za-z0-9_]{50,255} (fine-grained PAT), "
+            "npm_[a-zA-Z0-9]{40,} (NPM classic), "
+            "a ${{ ... }} expression (e.g. ${{ github.token }}, "
+            "${{ secrets.GITHUB_TOKEN }}), "
+            "or a $VAR env-var reference",
         )
 
     def validate_namespace_with_lookahead(self, namespace: str) -> tuple[bool, str]:

--- a/docs/audit/nitpicker-findings.md
+++ b/docs/audit/nitpicker-findings.md
@@ -1,11 +1,11 @@
 # Nitpicker Findings
 
 Generated: 2026-04-30
-Last validated: 2026-05-04 (Pass 13 — fixes applied)
+Last validated: 2026-05-25 (Pass 15 — additional fixes from validation pass)
 
 ## Summary
 
-- Total: 95 | Open: 1 | Fixed: 94 | Invalid: 0
+- Total: 99 | Open: 1 | Fixed: 98 | Invalid: 0
 
 ## Open Findings
 
@@ -497,6 +497,107 @@ then reference only `$COMPOSER_ARGS` in the run body.
 -->
 
 ## Fixed
+
+### Pass 15 — 2026-05-25
+
+#### [N-099] `_tests/framework/validation.py` and `_tests/shared/validation_core.py` token regex updated without unit tests
+
+Category: tests
+Area: `_tests/shared/validation_core.py`, `_tests/framework/validation.py`
+Problem: Pass 14 updated the installation-token regex in both test-framework
+modules without adding unit tests to exercise the new format. The shared
+`ValidationCore` class is invoked via CLI from ShellSpec specs (`uv run
+validation_core.py --validate ...`), so a regex regression would only surface
+when a downstream spec exercises the exact `ghs_APPID_JWT` shape — which none did.
+Evidence: `_tests/shared/` contained only `test_docker_image_regex.py` before this
+pass; no test asserts the behaviour of `ValidationCore.validate_github_token` or
+`ActionValidator.validate_github_token`.
+Impact: A future change to either regex could silently break ShellSpec validation
+runs without any local-test signal.
+Fixed: 2026-05-25
+Notes: Added `_tests/shared/test_token_regex.py` (14 cases) and
+`_tests/framework/test_action_validator_token.py` (8 cases). Coverage includes
+stateful/stateless ghs*, JWT realistic shape, minimum/upper-bound length
+boundaries (36, 1024), invalid-char rejection, classic ghp*, fine-grained
+github*pat*, GitHub expressions, and wrong-prefix rejection.
+
+#### [N-098] Fixture `"ghs_ stateless minimum length (36 body chars)"` body was 37 chars, not 36
+
+Category: tests
+Area: `validate-inputs/tests/fixtures/version_test_data.py`
+Problem: `("ghs_1_" + "a" * 30 + "." + "b" * 4, "ghs_ stateless minimum length (36
+body chars)")` — body length is 2 + 30 + 1 + 4 = 37 chars, but the label says 36.
+The test passed (37 ≥ 36) but did not exercise the boundary it claimed to.
+Evidence: Hand-count and `python3 -c "print(len('1_' + 'a'*30 + '.' + 'b'*4))"` → 37.
+Impact: Minimum-length boundary was untested — a regex regression to `{37,}` would
+have been masked.
+Fixed: 2026-05-25
+Notes: Corrected to `"ghs_1_" + "a" * 30 + ".y.z"` (body = 36). Added explicit
+1024-char upper-bound case to VALID and 1025-char over-bound case to INVALID.
+Mirror boundary test (`test_ghs_length_boundaries`) added to `test_token.py` and
+the generator template.
+
+#### [N-097] `scripts/generate-tests.py` `_generate_input_test_cases` had unused `config` parameter with `# noqa: ARG002` suppression
+
+Category: maintainability
+Area: `validate-inputs/scripts/generate-tests.py`
+Problem: The function signature was `_generate_input_test_cases(self, input_name:
+str, config: dict)` but `config` was never read inside the function body — it was
+silenced with `# noqa: ARG002`. Per `.claude/rules/fix-pre-existing-issues.md`,
+suppression directives are not permitted in place of root-cause fixes.
+Evidence: pyright diagnostic at line 266 — `"config" is not accessed`. Function
+body relies entirely on regex matching against `input_name`.
+Impact: Dead parameter clutters the API and masks intent for future maintainers.
+Fixed: 2026-05-25
+Notes: Removed the `config` parameter from the signature and the call site at line 204. Updated all five call sites in `tests/test_generate_tests.py` accordingly.
+Test suite remains green (786 tests pass).
+
+### Pass 14 — 2026-05-25
+
+#### [N-096] `validate-inputs` rejects new stateless `ghs_` installation tokens with "Invalid token format"
+
+Category: correctness
+Area: `validate-inputs/validators/token.py`, `validate-inputs/validators/security.py`,
+`_tests/shared/validation_core.py`, `_tests/framework/validation.py`
+Problem: GitHub began rolling out a new stateless installation-token format on
+2026-04-27 (`ghs_APPID_JWT`, ~520 chars, two dots, includes underscores). At workflow
+runtime, `${{ github.token }}` and `${{ secrets.GITHUB_TOKEN }}` expand to one of these
+tokens — which the validator's `^ghs_[a-zA-Z0-9]{36}$` regex rejected because it
+required exactly 36 alphanumeric chars after the prefix. Every action that calls
+`validate-inputs` with the runtime `github.token` therefore failed with
+"Invalid token format".
+Evidence: Official docs:
+<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats>
+("If your application expects or relies on installation tokens being exactly 40
+characters long, it may not handle this new token format correctly") and
+<https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header>
+("A stateless token is a `ghs_`-prefixed JWT. It is longer (~520 characters) and
+contains two dots… Our recommended regex to match both new and current format tokens is
+`ghs_[A-Za-z0-9\._]{36,}`"). Affected actions: ansible-lint-fix, codeql-analysis,
+csharp-publish, pr-lint, pre-commit, python-lint-fix, security-scan, stale,
+terraform-lint-fix (any path that passes the runtime `github.token` to validate-inputs).
+Impact: Blocks every action that uses `validate-inputs` with the runtime GitHub token.
+Fixed: 2026-05-25
+Notes: Updated four regex sites to GitHub's recommended pattern (with anchors and a
+sane upper bound of 1024 chars):
+
+- `validate-inputs/validators/token.py` — `github_installation` pattern now
+  `^ghs_[A-Za-z0-9._]{36,1024}$`; updated error message to document both formats.
+- `validate-inputs/validators/security.py` — `_check_github_tokens` `ghs_` pattern
+  now `ghs_[A-Za-z0-9._]{36,}` so leak detection catches the new format too.
+- `_tests/shared/validation_core.py` and `_tests/framework/validation.py` — same
+  installation regex update; same error message update.
+
+Added test coverage: `test_ghs_stateful_token`, `test_ghs_stateless_jwt_token`,
+`test_ghs_stateless_rejects_invalid_chars`, `test_ghs_too_short` in
+`tests/test_token.py`. Extended `GITHUB_TOKEN_VALID`/`INVALID` fixtures with realistic
+stateless JWT, minimum-length stateless, three-part JWT, char-class violations, and
+length-boundary cases — these feed the parametrized `test_token_validator.py`. Also
+updated `scripts/generate-tests.py` template so regenerated tests carry the new
+coverage and fixed three pre-existing template bugs (`ghp_ + "a" * 32` → `36`,
+`""` invalid check → `"", required=True`, removed reference to nonexistent
+`validate_pypi_token` method). Full test suite now 783/783 passing (was 763). Verified
+end-to-end with a synthetic 460-char stateless JWT token.
 
 ### Pass 13 — 2026-05-04
 

--- a/validate-inputs/scripts/generate-tests.py
+++ b/validate-inputs/scripts/generate-tests.py
@@ -200,8 +200,8 @@ Describe '{description} Input Validation'
 """
 
         # Add input-specific validation tests
-        for input_name, config in inputs.items():
-            test_cases = self._generate_input_test_cases(input_name, config)
+        for input_name in inputs:
+            test_cases = self._generate_input_test_cases(input_name)
             if test_cases:
                 content += f"""
   Context '{input_name} validation'
@@ -260,16 +260,11 @@ Describe '{description} Input Validation'
         # Default fallback
         return "test-value"
 
-    def _generate_input_test_cases(
-        self,
-        input_name: str,
-        config: dict,  # noqa: ARG002
-    ) -> list[str]:
+    def _generate_input_test_cases(self, input_name: str) -> list[str]:
         """Generate test cases for a specific input.
 
         Args:
             input_name: Name of the input
-            config: Input configuration
 
         Returns:
             List of test case strings
@@ -470,8 +465,8 @@ class Test{class_name}:
         return '''
     def test_valid_github_token(self):
         """Test valid GitHub tokens."""
-        # Classic PAT (36 chars)
-        assert self.validator.validate_github_token("ghp_" + "a" * 32) is True
+        # Classic PAT (4 + 36 chars)
+        assert self.validator.validate_github_token("ghp_" + "a" * 36) is True
         # Fine-grained PAT (82 chars)
         assert self.validator.validate_github_token("github_pat_" + "a" * 71) is True
         # GitHub expression
@@ -481,14 +476,49 @@ class Test{class_name}:
         """Test invalid GitHub tokens."""
         assert self.validator.validate_github_token("invalid") is False
         assert self.validator.validate_github_token("ghp_short") is False
-        assert self.validator.validate_github_token("") is False
+        assert self.validator.validate_github_token("", required=True) is False
+
+    def test_ghs_stateful_token(self):
+        """Stateful installation token: ghs_ + 36 alphanumeric (40 chars total)."""
+        assert self.validator.validate_github_token("ghs_" + "a" * 36) is True
+        assert self.validator.validate_github_token("ghs_" + "A1B2c3" * 6) is True
+
+    def test_ghs_stateless_jwt_token(self):
+        """Stateless installation token: ghs_APPID_JWT format with dots and underscores.
+
+        Per GitHub (2026-04-27 rollout), installation tokens may now be ~520-char JWTs
+        with two dots. The validator must accept both formats.
+        """
+        jwt_header = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"
+        jwt_payload = "a" * 200
+        jwt_signature = "b" * 256
+        stateless = f"ghs_1234567_{jwt_header}.{jwt_payload}.{jwt_signature}"
+        assert self.validator.validate_github_token(stateless) is True
+        # Minimum stateless: ghs_ + 36 body chars including underscores and dots
+        assert self.validator.validate_github_token("ghs_1_" + "x" * 30 + ".y.z") is True
+
+    def test_ghs_stateless_rejects_invalid_chars(self):
+        """ghs_ pattern allows only [A-Za-z0-9._] after the prefix."""
+        assert self.validator.validate_github_token("ghs_" + "a" * 35 + "+") is False
+        assert self.validator.validate_github_token("ghs_" + "a" * 35 + "/") is False
+        assert self.validator.validate_github_token("ghs_" + "a" * 35 + " ") is False
+
+    def test_ghs_too_short(self):
+        """ghs_ rejects bodies shorter than 36 chars."""
+        assert self.validator.validate_github_token("ghs_" + "a" * 35) is False
+        assert self.validator.validate_github_token("ghs_short") is False
+
+    def test_ghs_length_boundaries(self):
+        """ghs_ body length must satisfy 36 <= len <= 1024 exactly."""
+        assert self.validator.validate_github_token("ghs_" + "a" * 36) is True
+        assert self.validator.validate_github_token("ghs_" + "a" * 35) is False
+        assert self.validator.validate_github_token("ghs_" + "a" * 1024) is True
+        assert self.validator.validate_github_token("ghs_" + "a" * 1025) is False
 
     def test_other_token_types(self):
         """Test other token types."""
-        # NPM token
-        assert self.validator.validate_npm_token("npm_" + "a" * 32) is True
-        # PyPI token
-        assert self.validator.validate_pypi_token("pypi-AgEIcHlwaS5vcmc" + "a" * 100) is True
+        # NPM token (npm_ + 40+ alphanumeric chars)
+        assert self.validator.validate_npm_token("npm_" + "a" * 40) is True
 '''
 
     def _add_boolean_tests(self) -> str:

--- a/validate-inputs/tests/fixtures/version_test_data.py
+++ b/validate-inputs/tests/fixtures/version_test_data.py
@@ -97,13 +97,28 @@ DOCKER_INVALID = [
 ]
 
 # GitHub token test cases
+# Stateless installation token format (ghs_APPID_JWT) was rolled out 2026-04-27.
+# Per GitHub: ~520 chars, two dots (JWT separators), underscores between app ID and JWT
+# parts. Both stateful (40 chars) and stateless formats must be accepted.
+# https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header
+_JWT_HEADER = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"  # 36 chars base64url
+_JWT_PAYLOAD = "a" * 200  # placeholder body
+_JWT_SIGNATURE = "b" * 256  # placeholder signature
+_GHS_STATELESS_REALISTIC = f"ghs_1234567_{_JWT_HEADER}.{_JWT_PAYLOAD}.{_JWT_SIGNATURE}"
+
 GITHUB_TOKEN_VALID = [
     ("github_pat_" + "a" * 71, "Fine-grained PAT"),  # 11 + 71 = 82 chars total (in 50-255 range)
     ("github_pat_" + "a" * 50, "Fine-grained PAT min length"),  # 11 + 50 = 61 chars total (minimum)
     ("ghp_" + "a" * 36, "Classic PAT"),  # 4 + 36 = 40 chars total
     ("gho_" + "a" * 36, "OAuth token"),  # 4 + 36 = 40 chars total
     ("ghu_" + "a" * 36, "User token"),
-    ("ghs_" + "a" * 36, "Installation token"),
+    ("ghs_" + "a" * 36, "Installation token (stateful, 40 chars)"),
+    (_GHS_STATELESS_REALISTIC, "Installation token (stateless JWT, ~520 chars)"),
+    # Body = 1 + 1 + 30 + 1 + 1 + 1 + 1 = 36 chars (regex {36,1024} minimum)
+    ("ghs_1_" + "a" * 30 + ".y.z", "ghs_ stateless minimum length (36 body chars)"),
+    ("ghs_APPID_" + "a" * 50 + "." + "b" * 50 + "." + "c" * 50, "ghs_ with three-part JWT"),
+    # Body = exactly 1024 chars (regex upper bound)
+    ("ghs_" + "a" * 1024, "ghs_ stateless at upper-bound length (1024 body chars)"),
     ("ghr_" + "a" * 36, "Refresh token"),
     ("${{ github.token }}", "GitHub Actions expression"),
     ("${{ secrets.GITHUB_TOKEN }}", "Secrets expression"),
@@ -115,6 +130,10 @@ GITHUB_TOKEN_INVALID = [
     ("ghp_short", "Too short"),
     ("wrong_prefix_" + "a" * 36, "Wrong prefix"),
     ("github_pat_" + "a" * 49, "PAT too short (min 50)"),
+    ("ghs_" + "a" * 35, "ghs_ too short (35 chars body)"),
+    ("ghs_" + "@" * 36, "ghs_ contains invalid chars"),
+    ("ghp_" + "a" * 36 + ".extra", "ghp_ does not allow dots (only ghs_ stateless does)"),
+    ("ghs_" + "a" * 1025, "ghs_ exceeds upper-bound length (1025 body chars)"),
 ]
 
 # Email test cases

--- a/validate-inputs/tests/test_generate_tests.py
+++ b/validate-inputs/tests/test_generate_tests.py
@@ -220,31 +220,31 @@ class TestTestGenerator:
     def test_generate_input_test_cases(self):
         """Test generation of input-specific test cases."""
         # Boolean input
-        cases = self.generator._generate_input_test_cases("dry-run", {})
+        cases = self.generator._generate_input_test_cases("dry-run")
         assert len(cases) == 1
         assert "should accept boolean values" in cases[0]
         assert "should reject invalid boolean" in cases[0]
 
         # Version input
-        cases = self.generator._generate_input_test_cases("version", {})
+        cases = self.generator._generate_input_test_cases("version")
         assert len(cases) == 1
         assert "should accept valid version" in cases[0]
         assert "should accept version with v prefix" in cases[0]
 
         # Token input
-        cases = self.generator._generate_input_test_cases("github-token", {})
+        cases = self.generator._generate_input_test_cases("github-token")
         assert len(cases) == 1
         assert "should accept GitHub token" in cases[0]
         assert "should accept classic PAT" in cases[0]
 
         # Path input
-        cases = self.generator._generate_input_test_cases("config-file", {})
+        cases = self.generator._generate_input_test_cases("config-file")
         assert len(cases) == 1
         assert "should accept valid path" in cases[0]
         assert "should reject path traversal" in cases[0]
 
         # No specific pattern
-        cases = self.generator._generate_input_test_cases("custom-input", {})
+        cases = self.generator._generate_input_test_cases("custom-input")
         assert len(cases) == 0
 
     def test_generate_pytest_content_by_type(self):

--- a/validate-inputs/tests/test_token.py
+++ b/validate-inputs/tests/test_token.py
@@ -32,6 +32,51 @@ class TestTokenValidator:
         assert self.validator.validate_github_token("ghp_short") is False
         assert self.validator.validate_github_token("", required=True) is False
 
+    def test_ghs_stateful_token(self):
+        """Stateful installation token: ghs_ + 36 alphanumeric (40 chars total)."""
+        assert self.validator.validate_github_token("ghs_" + "a" * 36) is True
+        assert self.validator.validate_github_token("ghs_" + "A1B2c3" * 6) is True
+
+    def test_ghs_stateless_jwt_token(self):
+        """Stateless installation token: ghs_APPID_JWT format with dots and underscores.
+
+        Per GitHub (2026-04-27 rollout), installation tokens may now be ~520-char JWTs
+        with two dots. The validator must accept both formats.
+        """
+        # Realistic stateless token: ghs_<APPID>_<header>.<payload>.<signature>
+        jwt_header = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"
+        jwt_payload = "a" * 200
+        jwt_signature = "b" * 256
+        stateless = f"ghs_1234567_{jwt_header}.{jwt_payload}.{jwt_signature}"
+        assert self.validator.validate_github_token(stateless) is True
+        # Minimum stateless: ghs_ + 36 body chars including underscores and dots
+        assert self.validator.validate_github_token("ghs_1_" + "x" * 30 + ".y.z") is True
+
+    def test_ghs_stateless_rejects_invalid_chars(self):
+        """ghs_ pattern allows only [A-Za-z0-9._] after the prefix."""
+        # Plus sign — base64 standard, not base64url; not in GitHub's recommended regex
+        assert self.validator.validate_github_token("ghs_" + "a" * 35 + "+") is False
+        # Slash — not allowed
+        assert self.validator.validate_github_token("ghs_" + "a" * 35 + "/") is False
+        # Space — never allowed in tokens
+        assert self.validator.validate_github_token("ghs_" + "a" * 35 + " ") is False
+
+    def test_ghs_too_short(self):
+        """ghs_ rejects bodies shorter than 36 chars."""
+        assert self.validator.validate_github_token("ghs_" + "a" * 35) is False
+        assert self.validator.validate_github_token("ghs_short") is False
+
+    def test_ghs_length_boundaries(self):
+        """ghs_ body length must satisfy 36 <= len <= 1024 exactly."""
+        # Exactly minimum — accepted
+        assert self.validator.validate_github_token("ghs_" + "a" * 36) is True
+        # One below minimum — rejected
+        assert self.validator.validate_github_token("ghs_" + "a" * 35) is False
+        # Exactly upper bound — accepted
+        assert self.validator.validate_github_token("ghs_" + "a" * 1024) is True
+        # One over upper bound — rejected
+        assert self.validator.validate_github_token("ghs_" + "a" * 1025) is False
+
     def test_other_token_types(self):
         """Test other token types."""
         # NPM token

--- a/validate-inputs/validators/security.py
+++ b/validate-inputs/validators/security.py
@@ -402,7 +402,10 @@ class SecurityValidator(BaseValidator):
             r"ghp_[a-zA-Z0-9]{36}",  # GitHub personal access token
             r"gho_[a-zA-Z0-9]{36}",  # GitHub OAuth token
             r"ghu_[a-zA-Z0-9]{36}",  # GitHub user token
-            r"ghs_[a-zA-Z0-9]{36}",  # GitHub server token
+            # GitHub installation token: stateful (ghs_<36 chars>) OR stateless JWT
+            # (ghs_APPID_JWT, ~520 chars, contains dots and underscores).
+            # GitHub's recommended regex catches both formats.
+            r"ghs_[A-Za-z0-9._]{36,}",
             r"ghr_[a-zA-Z0-9]{36}",  # GitHub refresh token
             r"github_pat_[a-zA-Z0-9_]{48,}",  # GitHub fine-grained PAT
         ]

--- a/validate-inputs/validators/token.py
+++ b/validate-inputs/validators/token.py
@@ -112,10 +112,18 @@ class TokenValidator(BaseValidator):
                 return True
 
         self.add_error(
-            "Invalid token format. Expected: ghp_* (40 chars), "
-            "github_pat_[A-Za-z0-9_]* (50-255 chars), gho_* (40 chars), ghu_* (40 chars), "
-            "ghs_* (40 chars stateful or ~520 chars stateless JWT), "
-            "ghr_* (40 chars), ghe_* (40 chars), or ${{ github.token }}",
+            "Invalid token format. Expected one of: "
+            "ghp_[a-zA-Z0-9]{36} (40 chars total — classic PAT), "
+            "gho_[a-zA-Z0-9]{36} (40 chars total — OAuth), "
+            "ghu_[a-zA-Z0-9]{36} (40 chars total — user-to-server), "
+            "ghs_[A-Za-z0-9._]{36,1024} (40-1028 chars total — installation; "
+            "stateful or stateless JWT), "
+            "ghr_[a-zA-Z0-9]{36} (40 chars total — refresh), "
+            "ghe_[a-zA-Z0-9]{36} (40 chars total — Enterprise), "
+            "github_pat_[A-Za-z0-9_]{50,255} (fine-grained PAT), "
+            "a ${{ ... }} expression (e.g. ${{ github.token }}, "
+            "${{ secrets.GITHUB_TOKEN }}), "
+            "or a $VAR / ${VAR} env-var reference",
         )
         return False
 

--- a/validate-inputs/validators/token.py
+++ b/validate-inputs/validators/token.py
@@ -27,9 +27,15 @@ class TokenValidator(BaseValidator):
         # User access token for GitHub App:
         # ghu_ + 36 = 40 chars total
         "github_user_app": r"^ghu_[a-zA-Z0-9]{36}$",
-        # Installation access token:
-        # ghs_ + 36 = 40 chars total
-        "github_installation": r"^ghs_[a-zA-Z0-9]{36}$",
+        # Installation access token (ghs_): two formats supported.
+        #
+        # 1. Stateful (legacy opaque): ghs_ + 36 chars, no dots.
+        # 2. Stateless (ghs_APPID_JWT): rolled out starting 2026-04-27.
+        #    JWT body with two dots, underscores, ~520 chars total.
+        #
+        # Matches GitHub's recommended regex: ghs_[A-Za-z0-9._]{36,}
+        # https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header
+        "github_installation": r"^ghs_[A-Za-z0-9._]{36,1024}$",
         # Refresh token for GitHub App:
         # ghr_ + 36 = 40 chars total
         "github_refresh": r"^ghr_[a-zA-Z0-9]{36}$",
@@ -108,7 +114,8 @@ class TokenValidator(BaseValidator):
         self.add_error(
             "Invalid token format. Expected: ghp_* (40 chars), "
             "github_pat_[A-Za-z0-9_]* (50-255 chars), gho_* (40 chars), ghu_* (40 chars), "
-            "ghs_* (40 chars), ghr_* (40 chars), ghe_* (40 chars), or ${{ github.token }}",
+            "ghs_* (40 chars stateful or ~520 chars stateless JWT), "
+            "ghr_* (40 chars), ghe_* (40 chars), or ${{ github.token }}",
         )
         return False
 


### PR DESCRIPTION
## Summary

- GitHub began rolling out a stateless installation-token format (`ghs_APPID_JWT`,
  ~520 chars with two dots and underscores) on 2026-04-27. The validator's old
  regex `^ghs_[a-zA-Z0-9]{36}$` rejected this, causing every action that calls
  `validate-inputs` with the runtime `github.token` to fail with
  "Invalid token format".
- Updates the regex in all four parallel implementations (production validator,
  secrets-leak detector, and the two test-framework mirrors) to GitHub's
  recommended pattern, and adds 22 new test cases covering both stateful and
  stateless formats with boundary checks.
- Cleans up three pre-existing bugs in `generate-tests.py` discovered while
  updating the template (wrong char counts, missing `required=True`, reference
  to non-existent `validate_pypi_token`), and removes an unused `config`
  parameter that was silenced with `# noqa: ARG002`.

## Affected actions

Every action that calls `validate-inputs` with the runtime GitHub token was
broken: `ansible-lint-fix`, `codeql-analysis`, `csharp-publish`, `pr-lint`,
`pre-commit`, `python-lint-fix`, `security-scan`, `stale`, `terraform-lint-fix`.

## Reference

- Official guidance:
  <https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header>
- GitHub's recommended regex: `ghs_[A-Za-z0-9\._]{36,}`
- Note from <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats>:
  > If your application expects or relies on installation tokens being exactly
  > 40 characters long, it may not handle this new token format correctly.

## Commits

1. `fix(validate-inputs): accept new stateless ghs_ installation token format`
   — core regex update across 4 parallel sites.
2. `test(validate-inputs): cover stateless ghs_ format with happy/sad cases`
   — adds 45 lines of test coverage to `test_token.py`, expands
   `version_test_data.py` fixtures with realistic JWT + boundary cases, adds
   two new test files in `_tests/` for the framework validators, fixes
   pre-existing generator template bugs.
3. `docs(audit): record N-096..N-099 ghs_ stateless format fixes`
   — appends Pass 14 and Pass 15 findings to `docs/audit/nitpicker-findings.md`.

## Test plan

- [x] Pytest: validate-inputs suite passes (786 tests).
- [x] Pytest: new test framework files pass (22 tests).
- [x] Boundary tests: body of exactly 36 and 1024 chars accepted; 35 and 1025
      rejected.
- [x] Char-class tests: `+`, `/`, ` ` all correctly rejected.
- [x] End-to-end: synthetic 460-char stateless JWT token validates cleanly.
- [x] Secrets-leak detector flags new format tokens embedded in unrelated
      inputs.
- [x] Ruff lint: clean.
- [ ] Optional: trigger one of the affected actions in CI with the runtime
      `github.token` to confirm the rollout token format is accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for GitHub App installation tokens in both stateful and stateless JWT-style formats.

* **Improvements**
  * Expanded GitHub token validation to accept a broader range of installation token formats and updated validation messaging.

* **Tests**
  * Added comprehensive test coverage for new token validation scenarios.

* **Documentation**
  * Updated audit documentation with latest validation findings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ivuorinen/actions/pull/587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->