### PR TITLE
docs(docker-testing-tools): document write_package failure + fix runbook

### DIFF
--- a/_tools/docker-testing-tools/README.md
+++ b/_tools/docker-testing-tools/README.md
@@ -125,6 +125,42 @@ The image is:
 - ✅ **Sudo access** - Available for emergency use only
 - ✅ **Transparent build** - Built with GitHub Actions
 
+## 🩺 Troubleshooting
+
+### `denied: permission_denied: write_package` on push to `main`
+
+**Symptom:** `build-testing-image.yml` fails at the _Build and push Docker image_
+step with `failed to push ghcr.io/<owner>/actions:main-testing-tools: denied:
+permission_denied: write_package`, while pull-request runs stay green (PR runs
+only build — the push is gated by `push: ${{ github.event_name != 'pull_request' }}`).
+
+**Cause:** the failure is at the **package's access-control layer**, not the
+workflow. The workflow already grants `packages: write`, logs in with
+`GITHUB_TOKEN`, and stamps the `org.opencontainers.image.source` label. The
+personal-account-scoped GHCR package lost the **inherited write access** for the
+repository's `GITHUB_TOKEN` — this happens when a package is re-connected from its
+settings page, or "Inherit access from source repository" is toggled off, leaving
+explicit permissions that no longer include the repo's workflow token.
+
+**Fix:** user-scoped packages have **no REST API** to grant a repository "Actions
+access" (that endpoint is organization-only), so either:
+
+1. **Non-destructive (UI):** package settings → _Manage Actions access_ →
+   re-enable _Inherit access from source repository_, or add the repository with
+   the **Write** role.
+2. **Delete and recreate (destructive):** delete the package, then re-run the
+   push — the recreate links the repo at creation via the source label, so write
+   access is inherited the supported way:
+
+   ```sh
+   gh api -X DELETE user/packages/container/actions
+   gh run rerun <failed-run-id> --repo <owner>/actions
+   ```
+
+   Side effects: the recreated package inherits the **repository's visibility**
+   (public for a public repo) and existing versions are wiped (acceptable here —
+   the image is regenerated on every push and has no other workflow consumers).
+
 ## 🚨 Migration Guide
 
 ### Before (Old Workflow)


### PR DESCRIPTION
## Context

CI run [27074454736](https://github.com/ivuorinen/actions/actions/runs/27074454736) of `build-testing-image.yml` failed on push to `main` with:

```
failed to push ghcr.io/ivuorinen/actions:main-testing-tools: denied: permission_denied: write_package
```

## Root cause (not a workflow bug)

The workflow YAML was already correct — `packages: write` set, `GITHUB_TOKEN` login, and the `org.opencontainers.image.source` label stamped. The block was at the **package access-control layer**: the personal-account-scoped GHCR package `ghcr.io/ivuorinen/actions` had lost the **inherited write access** for the repo's `GITHUB_TOKEN` (inheritance toggled off / re-connected from the package settings page). That silently broke **every push-to-`main`** since ~2025-10-14, while PR runs stayed green because PRs never push (`push: ${{ github.event_name != 'pull_request' }}`).

## Operational fix already applied (2026-06-07)

`gh api -X DELETE user/packages/container/actions` then re-ran the failed workflow. The package was recreated fresh, linking the repo at creation via the source label → auto-inherited write access. The re-run completed green (push step ✓, image smoke-test ✓). Note: the recreated package now inherits the **public** repo visibility.

## This PR

The fix required **no repository code change**. This PR adds the missing in-repo **runbook** so the next person hitting `write_package` doesn't re-derive the diagnosis — a Troubleshooting section in the docker-testing-tools README covering symptom, root cause, and both remediations (UI inherit/grant, or delete + recreate).

## Verification

- markdownlint-cli2: 0 errors · prettier: clean · pre-commit hooks: all passed
- pin-check: PASS (no `uses:` added) · security audit (scoped to diff): PASS (docs only, no new surface)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a new Troubleshooting section providing guidance on resolving GHCR push failures related to permission issues, including diagnosis information and two remediation approaches with example commands for quick resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->