### PR TITLE
fix(ci): resolve zizmor findings, harden release/docs tooling

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -23,7 +23,7 @@ We will respond within 48 hours and work on a fix if validated.
 This repository implements:
 
 - CodeQL scanning
-- Semgrep static analysis
+- Opengrep static analysis (open-source fork of Semgrep CE)
 - Gitleaks secret scanning
 - Dependency Review
 - MegaLinter code analysis
@@ -50,12 +50,11 @@ When using these actions:
 The following table shows available secrets (auto-provisioned secrets are provided by
 GitHub, optional secrets require manual repository configuration):
 
-| Secret Name         | Description                                                       | Requirement |
-| ------------------- | ----------------------------------------------------------------- | ----------- |
-| `GITHUB_TOKEN`      | GitHub token for workflow authentication (automatically provided) | Auto        |
-| `GITLEAKS_LICENSE`  | License for Gitleaks scanning                                     | Optional    |
-| `FIXIMUS_TOKEN`     | Enhanced token for automated fix PRs                              | Optional    |
-| `SEMGREP_APP_TOKEN` | Token for Semgrep static analysis                                 | Optional    |
+| Secret Name        | Description                                                       | Requirement |
+| ------------------ | ----------------------------------------------------------------- | ----------- |
+| `GITHUB_TOKEN`     | GitHub token for workflow authentication (automatically provided) | Auto        |
+| `GITLEAKS_LICENSE` | License for Gitleaks scanning                                     | Optional    |
+| `FIXIMUS_TOKEN`    | Enhanced token for automated fix PRs                              | Optional    |
 
 ## Security Workflows
 
@@ -63,7 +62,7 @@ This repository includes several security-focused workflows:
 
 1. **PR Security Analysis** (`security-suite.yml`)
    - Comprehensive security scanning on pull requests
-   - Semgrep static analysis
+   - Opengrep static analysis
    - Dependency vulnerability checks
    - Creates automated fix PRs
 

--- a/.github/workflows/action-security.yml
+++ b/.github/workflows/action-security.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Security Scan
         id: security-scan

--- a/.github/workflows/build-testing-image.yml
+++ b/.github/workflows/build-testing-image.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -87,7 +89,7 @@ jobs:
             echo "## 🐋 Docker Image Built Successfully"
             echo ""
             echo "**Image**: \`ghcr.io/${{ github.repository_owner }}/actions:testing-tools\`"
-            echo "**Tags**: ${{ steps.meta.outputs.tags }}"
+            echo "**Tags**: ${STEPS_META_OUTPUTS_TAGS}"
             echo ""
             echo "### Usage in GitHub Actions"
             echo ""
@@ -110,3 +112,5 @@ jobs:
             echo "- shellcheck, jq, kcov, GitHub CLI"
             echo "- Node.js LTS, Python 3, build tools"
           } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          STEPS_META_OUTPUTS_TAGS: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/codeql-new.yml
+++ b/.github/workflows/codeql-new.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false
 
       - name: Run CodeQL Analysis
         uses: ./codeql-analysis

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Docs Drift Check
+
+on:
+  pull_request:
+    paths:
+      - '**/action.yml'
+      - '**/README.md'
+      - package.json
+      - package-lock.json
+      - Makefile
+
+permissions: {}
+
+jobs:
+  docs-drift:
+    name: Action README drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install pinned tooling
+        run: npm ci
+
+      - name: Regenerate action documentation
+        run: |
+          set -eu
+          # npm ci installed the pinned action-docs + prettier; `make docs`
+          # generates each action README and prettier-formats it in place, so
+          # its output is the committed style and this gate stays reproducible.
+          make docs
+
+      - name: Check for action README drift
+        run: |
+          set -eu
+          # Only generated action READMEs (dirs that contain an action.yml) are
+          # gated; formatting drift in other docs is out of scope for this check.
+          drift=$(find . -mindepth 2 -maxdepth 2 -name action.yml \
+            | sed 's|/action.yml|/README.md|' \
+            | while IFS= read -r readme; do
+                git diff --quiet -- "$readme" || printf '%s\n' "$readme"
+              done)
+          if [ -n "$drift" ]; then
+            echo "::error::Action README(s) are out of date. Run 'make docs' and commit the result." >&2
+            printf 'Stale: %s\n' "$drift" >&2
+            exit 1
+          fi
+          echo "All action READMEs are up to date."

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
         with:
           fetch-depth: 0 # Fetch all history and tags for comparison
+          persist-credentials: false
 
       - name: Create daily release
         id: daily-version
@@ -90,6 +91,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.new-daily-release.outputs.version }}
+          persist-credentials: false
       - name: Create source archive
         env:
           TAG: ${{ needs.new-daily-release.outputs.version }}
@@ -119,6 +121,7 @@ jobs:
       - uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
         with:
           ref: ${{ needs.new-daily-release.outputs.version }}
+          persist-credentials: false
       - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           format: cyclonedx-json

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           token: ${{ secrets.FIXIMUS_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run MegaLinter
         id: pr-lint
@@ -78,9 +79,11 @@ jobs:
       - name: Check Results
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          VALIDATION_STATUS: ${{ steps.pr-lint.outputs.validation_status }}
         with:
           script: |
-            const status = '${{ steps.pr-lint.outputs.validation_status }}';
+            const status = process.env.VALIDATION_STATUS;
             const conclusion = status === 'success' ? 'success' : 'failure';
 
             const summary = `## MegaLinter Results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,15 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
-      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          generate_release_notes: true
+          persist-credentials: false
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -eu
+          gh release create "$TAG" --verify-tag --generate-notes
 
   provenance:
     needs: release
@@ -31,6 +37,8 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false
       - name: Create source archive
         env:
           TAG: ${{ github.ref_name }}
@@ -57,6 +65,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false
       - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           format: cyclonedx-json

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -207,7 +207,7 @@ jobs:
                 }
               }
             } catch (error) {
-              console.log('Opengrep SARIF parsing completed');
+              core.warning(`Failed to parse opengrep.sarif: ${error.message}`);
             }
 
             // Parse TruffleHog results (NDJSON format - one JSON object per line)

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -36,6 +36,7 @@ jobs:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Fetch PR Base
         env:
@@ -71,13 +72,23 @@ jobs:
             --enableRetired --enableExperimental --failOnCVSS 0
         continue-on-error: true
 
-      - name: Semgrep Static Analysis
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1
-        with:
-          config: 'auto'
-          generateSarif: 'true'
+      - name: Opengrep Static Analysis
+        # Opengrep is the open-source (LGPL) fork of Semgrep CE and runs the same
+        # Semgrep-compatible rules. Installed from the pinned release binary,
+        # verified by SHA-256, rather than a floating install-script ref — this
+        # keeps the pin-everything trust root (a release tag is mutable; the
+        # digest is not). 'p/default' is the public registry ruleset resolvable
+        # without an account token. Update OPENGREP_SHA256 with OPENGREP_VERSION.
         env:
-          SEMGREP_APP_TOKEN: ${{ github.event_name != 'pull_request_target' && secrets.SEMGREP_APP_TOKEN || '' }}
+          OPENGREP_VERSION: v1.22.0
+          OPENGREP_SHA256: 45bcd58440e397ed52c50e953ccf5948909ea77087c9186fc7d277216f62e319
+        run: |
+          set -eu
+          curl -fsSL -o /tmp/opengrep \
+            "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          printf '%s  /tmp/opengrep\n' "$OPENGREP_SHA256" | sha256sum -c -
+          chmod +x /tmp/opengrep
+          /tmp/opengrep scan --config p/default --sarif-output=opengrep.sarif .
         continue-on-error: true
 
       - name: TruffleHog Secret Scan
@@ -176,10 +187,10 @@ jobs:
               console.log('No OWASP results found');
             }
 
-            // Parse Semgrep SARIF results
+            // Parse Opengrep SARIF results
             try {
-              if (fs.existsSync('semgrep.sarif')) {
-                const sarifContent = JSON.parse(fs.readFileSync('semgrep.sarif', 'utf8'));
+              if (fs.existsSync('opengrep.sarif')) {
+                const sarifContent = JSON.parse(fs.readFileSync('opengrep.sarif', 'utf8'));
                 if (sarifContent.runs && sarifContent.runs[0] && sarifContent.runs[0].results) {
                   const run = sarifContent.runs[0];
                   const rules = run.tool?.driver?.rules || [];
@@ -196,7 +207,7 @@ jobs:
                 }
               }
             } catch (error) {
-              console.log('Semgrep SARIF parsing completed');
+              console.log('Opengrep SARIF parsing completed');
             }
 
             // Parse TruffleHog results (NDJSON format - one JSON object per line)

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -36,5 +36,7 @@ jobs:
     steps:
       - name: ⤵️ Checkout Repository
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false
       - name: ⤵️ Sync Latest Labels Definitions
         uses: ./sync-labels

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false
 
       - name: Setup test environment
         uses: ./.github/actions/setup-test-environment
@@ -108,6 +110,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false
 
       - name: Setup test environment
         uses: ./.github/actions/setup-test-environment
@@ -172,6 +176,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false
 
       - name: Setup test environment
         uses: ./.github/actions/setup-test-environment
@@ -240,6 +246,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
+        with:
+          persist-credentials: false
 
       - name: Setup test environment
         uses: ./.github/actions/setup-test-environment

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,14 @@ repos:
     hooks:
       - id: generate-docs-format-lint
         name: Generate docs, format, and lint
-        entry: bash -c 'make all'
+        # Runs the docs/format/lint targets directly — NOT `make all`, whose
+        # `precommit` step would re-invoke pre-commit and recurse infinitely.
+        entry: bash -c 'make docs format lint'
         language: system
         pass_filenames: false
-        types: [markdown, python, yaml]
+        # types_or (any of), not types (which is an AND — no file is markdown
+        # AND python AND yaml, so the hook never matched and never ran).
+        types_or: [markdown, python, yaml]
         files: ^(docs/.*|README\.md|CONTRIBUTING\.md|CHANGELOG\.md|.*\.py|.*\.ya?ml)$
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.11.19

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ in hook commands
 ### Skills & Subagents
 
 | When                                        | Run                                       |
-| ------------------------------------------- | ----------------------------------------- |
+|---------------------------------------------|-------------------------------------------|
 | After modifying an action                   | `/action-health <name>`                   |
 | After creating an action modeled on another | `/compare-actions <source> <new>`         |
 | Before creating a PR                        | `/pin-check` and `/security-audit`        |
@@ -268,7 +268,7 @@ You do NOT need to manually instruct subagents about context-mode.
 ### ctx commands
 
 | Command       | Action                                                                                |
-| ------------- | ------------------------------------------------------------------------------------- |
+|---------------|---------------------------------------------------------------------------------------|
 | `ctx stats`   | Call the `ctx_stats` MCP tool and display the full output verbatim                    |
 | `ctx doctor`  | Call the `ctx_doctor` MCP tool, run the returned shell command, display as checklist  |
 | `ctx upgrade` | Call the `ctx_upgrade` MCP tool, run the returned shell command, display as checklist |

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ docs: ## Generate documentation for all actions
 			$(SED_CMD) "s|\*\*\*||g" "$$dir/README.md"; \
 			$(SED_CMD) "s|@main|@vYYYY.MM.DD|g" "$$dir/README.md"; \
 			[ "$(UNAME_S)" = "Darwin" ] && rm -f "$$dir/README.md.bak"; \
+			npx --yes prettier --write "$$dir/README.md" >/dev/null 2>&1; \
+			npx --yes markdown-table-formatter "$$dir/README.md" >/dev/null 2>&1; \
 			echo "$(GREEN)✅ Updated $$dir/README.md$(RESET)"; \
 		else \
 			echo "$(RED)⚠️ Failed to update $$dir/README.md$(RESET)" | tee -a $(LOG_FILE); \

--- a/README.md
+++ b/README.md
@@ -29,66 +29,66 @@ This repository contains **25 reusable GitHub Actions** for CI/CD automation.
 ### Quick Reference (25 Actions)
 
 | Icon | Action                                               | Category   | Description                                                     | Key Features                                 |
-| :--: | :--------------------------------------------------- | :--------- | :-------------------------------------------------------------- | :------------------------------------------- |
+|:----:|:-----------------------------------------------------|:-----------|:----------------------------------------------------------------|:---------------------------------------------|
 |  📦  | [`ansible-lint-fix`][ansible-lint-fix]               | Linting    | Lints and fixes Ansible playbooks, commits changes, and uplo... | Caching, Auto-detection, Token auth, Outputs |
-|  ✅  | [`biome-lint`][biome-lint]                           | Linting    | Run Biome linter in check or fix mode                           | Caching, Auto-detection, Token auth, Outputs |
-|  🛡️  | [`codeql-analysis`][codeql-analysis]                 | Repository | Run CodeQL security analysis for a single language with conf... | Auto-detection, Token auth, Outputs          |
-|  🖼️  | [`compress-images`][compress-images]                 | Repository | Compress images on demand (workflow_dispatch), and at 11pm e... | Token auth, Outputs                          |
+|  ✅   | [`biome-lint`][biome-lint]                           | Linting    | Run Biome linter in check or fix mode                           | Caching, Auto-detection, Token auth, Outputs |
+| 🛡️  | [`codeql-analysis`][codeql-analysis]                 | Repository | Run CodeQL security analysis for a single language with conf... | Auto-detection, Token auth, Outputs          |
+| 🖼️  | [`compress-images`][compress-images]                 | Repository | Compress images on demand (workflow_dispatch), and at 11pm e... | Token auth, Outputs                          |
 |  📝  | [`csharp-build`][csharp-build]                       | Build      | Builds and tests C# projects.                                   | Caching, Auto-detection, Token auth, Outputs |
 |  📝  | [`csharp-lint-check`][csharp-lint-check]             | Linting    | Runs linters like StyleCop or dotnet-format for C# code styl... | Caching, Auto-detection, Token auth, Outputs |
 |  📦  | [`csharp-publish`][csharp-publish]                   | Publishing | Publishes a C# project to GitHub Packages.                      | Caching, Auto-detection, Token auth, Outputs |
 |  📦  | [`docker-build`][docker-build]                       | Build      | Builds a Docker image for multiple architectures with enhanc... | Caching, Auto-detection, Token auth, Outputs |
 |  ☁️  | [`docker-publish`][docker-publish]                   | Publishing | Simple wrapper to publish Docker images to GitHub Packages a... | Token auth, Outputs                          |
-|  ✅  | [`eslint-lint`][eslint-lint]                         | Linting    | Run ESLint in check or fix mode with advanced configuration ... | Caching, Auto-detection, Token auth, Outputs |
+|  ✅   | [`eslint-lint`][eslint-lint]                         | Linting    | Run ESLint in check or fix mode with advanced configuration ... | Caching, Auto-detection, Token auth, Outputs |
 |  📦  | [`go-build`][go-build]                               | Build      | Builds the Go project.                                          | Caching, Auto-detection, Token auth, Outputs |
 |  📝  | [`go-lint`][go-lint]                                 | Linting    | Run golangci-lint with advanced configuration, caching, and ... | Caching, Token auth, Outputs                 |
 |  📝  | [`language-version-detect`][language-version-detect] | Setup      | DEPRECATED: This action is deprecated. Inline version detect... | Auto-detection, Token auth, Outputs          |
 |  📦  | [`npm-publish`][npm-publish]                         | Publishing | Publishes the package to the NPM registry with configurable ... | Caching, Auto-detection, Token auth, Outputs |
 |  📦  | [`npm-semantic-release`][npm-semantic-release]       | Other      | Runs semantic-release for automated npm versioning and publi... | Caching, Auto-detection, Outputs             |
-|  ✅  | [`php-tests`][php-tests]                             | Testing    | Run PHPUnit tests with optional Laravel setup and Composer d... | Caching, Auto-detection, Token auth, Outputs |
-|  ✅  | [`pr-lint`][pr-lint]                                 | Linting    | Runs MegaLinter against pull requests                           | Caching, Auto-detection, Token auth, Outputs |
+|  ✅   | [`php-tests`][php-tests]                             | Testing    | Run PHPUnit tests with optional Laravel setup and Composer d... | Caching, Auto-detection, Token auth, Outputs |
+|  ✅   | [`pr-lint`][pr-lint]                                 | Linting    | Runs MegaLinter against pull requests                           | Caching, Auto-detection, Token auth, Outputs |
 |  📦  | [`pre-commit`][pre-commit]                           | Linting    | Runs pre-commit on the repository and pushes the fixes back ... | Auto-detection, Token auth, Outputs          |
-|  ✅  | [`prettier-lint`][prettier-lint]                     | Linting    | Run Prettier in check or fix mode with advanced configuratio... | Caching, Auto-detection, Token auth, Outputs |
+|  ✅   | [`prettier-lint`][prettier-lint]                     | Linting    | Run Prettier in check or fix mode with advanced configuratio... | Caching, Auto-detection, Token auth, Outputs |
 |  📝  | [`python-lint-fix`][python-lint-fix]                 | Linting    | Lints and fixes Python files, commits changes, and uploads S... | Caching, Auto-detection, Token auth, Outputs |
 |  📦  | [`release-monthly`][release-monthly]                 | Repository | Creates a release for the current month, incrementing patch ... | Token auth, Outputs                          |
-|  🛡️  | [`security-scan`][security-scan]                     | Security   | Comprehensive security scanning for GitHub Actions including... | Caching, Token auth, Outputs                 |
+| 🛡️  | [`security-scan`][security-scan]                     | Security   | Comprehensive security scanning for GitHub Actions including... | Caching, Token auth, Outputs                 |
 |  📦  | [`stale`][stale]                                     | Repository | A GitHub Action to close stale issues and pull requests.        | Token auth, Outputs                          |
-|  🏷️  | [`sync-labels`][sync-labels]                         | Repository | Sync labels from a YAML file to a GitHub repository             | Token auth, Outputs                          |
-|  🖥️  | [`terraform-lint-fix`][terraform-lint-fix]           | Linting    | Lints and fixes Terraform files with advanced validation and... | Token auth, Outputs                          |
+| 🏷️  | [`sync-labels`][sync-labels]                         | Repository | Sync labels from a YAML file to a GitHub repository             | Token auth, Outputs                          |
+| 🖥️  | [`terraform-lint-fix`][terraform-lint-fix]           | Linting    | Lints and fixes Terraform files with advanced validation and... | Token auth, Outputs                          |
 
 ### Actions by Category
 
 #### 🔧 Setup (1 action)
 
 | Action                                                  | Description                                           | Languages                      | Features                            |
-| :------------------------------------------------------ | :---------------------------------------------------- | :----------------------------- | :---------------------------------- |
+|:--------------------------------------------------------|:------------------------------------------------------|:-------------------------------|:------------------------------------|
 | 📝 [`language-version-detect`][language-version-detect] | DEPRECATED: This action is deprecated. Inline vers... | PHP, Python, Go, .NET, Node.js | Auto-detection, Token auth, Outputs |
 
 #### 📝 Linting (10 actions)
 
-| Action                                        | Description                                           | Languages                                    | Features                                     |
-| :-------------------------------------------- | :---------------------------------------------------- | :------------------------------------------- | :------------------------------------------- |
-| 📦 [`ansible-lint-fix`][ansible-lint-fix]     | Lints and fixes Ansible playbooks, commits changes... | Ansible, YAML                                | Caching, Auto-detection, Token auth, Outputs |
-| ✅ [`biome-lint`][biome-lint]                 | Run Biome linter in check or fix mode                 | JavaScript, TypeScript, JSON                 | Caching, Auto-detection, Token auth, Outputs |
-| 📝 [`csharp-lint-check`][csharp-lint-check]   | Runs linters like StyleCop or dotnet-format for C#... | C#, .NET                                     | Caching, Auto-detection, Token auth, Outputs |
-| ✅ [`eslint-lint`][eslint-lint]               | Run ESLint in check or fix mode with advanced conf... | JavaScript, TypeScript                       | Caching, Auto-detection, Token auth, Outputs |
-| 📝 [`go-lint`][go-lint]                       | Run golangci-lint with advanced configuration, cac... | Go                                           | Caching, Token auth, Outputs                 |
-| ✅ [`pr-lint`][pr-lint]                       | Runs MegaLinter against pull requests                 | Conventional Commits                         | Caching, Auto-detection, Token auth, Outputs |
-| 📦 [`pre-commit`][pre-commit]                 | Runs pre-commit on the repository and pushes the f... | Python, Multiple Languages                   | Auto-detection, Token auth, Outputs          |
-| ✅ [`prettier-lint`][prettier-lint]           | Run Prettier in check or fix mode with advanced co... | JavaScript, TypeScript, Markdown, YAML, JSON | Caching, Auto-detection, Token auth, Outputs |
-| 📝 [`python-lint-fix`][python-lint-fix]       | Lints and fixes Python files, commits changes, and... | Python                                       | Caching, Auto-detection, Token auth, Outputs |
+| Action                                         | Description                                           | Languages                                    | Features                                     |
+|:-----------------------------------------------|:------------------------------------------------------|:---------------------------------------------|:---------------------------------------------|
+| 📦 [`ansible-lint-fix`][ansible-lint-fix]      | Lints and fixes Ansible playbooks, commits changes... | Ansible, YAML                                | Caching, Auto-detection, Token auth, Outputs |
+| ✅ [`biome-lint`][biome-lint]                   | Run Biome linter in check or fix mode                 | JavaScript, TypeScript, JSON                 | Caching, Auto-detection, Token auth, Outputs |
+| 📝 [`csharp-lint-check`][csharp-lint-check]    | Runs linters like StyleCop or dotnet-format for C#... | C#, .NET                                     | Caching, Auto-detection, Token auth, Outputs |
+| ✅ [`eslint-lint`][eslint-lint]                 | Run ESLint in check or fix mode with advanced conf... | JavaScript, TypeScript                       | Caching, Auto-detection, Token auth, Outputs |
+| 📝 [`go-lint`][go-lint]                        | Run golangci-lint with advanced configuration, cac... | Go                                           | Caching, Token auth, Outputs                 |
+| ✅ [`pr-lint`][pr-lint]                         | Runs MegaLinter against pull requests                 | Conventional Commits                         | Caching, Auto-detection, Token auth, Outputs |
+| 📦 [`pre-commit`][pre-commit]                  | Runs pre-commit on the repository and pushes the f... | Python, Multiple Languages                   | Auto-detection, Token auth, Outputs          |
+| ✅ [`prettier-lint`][prettier-lint]             | Run Prettier in check or fix mode with advanced co... | JavaScript, TypeScript, Markdown, YAML, JSON | Caching, Auto-detection, Token auth, Outputs |
+| 📝 [`python-lint-fix`][python-lint-fix]        | Lints and fixes Python files, commits changes, and... | Python                                       | Caching, Auto-detection, Token auth, Outputs |
 | 🖥️ [`terraform-lint-fix`][terraform-lint-fix] | Lints and fixes Terraform files with advanced vali... | Terraform, HCL                               | Token auth, Outputs                          |
 
 #### 🧪 Testing (1 action)
 
-| Action                      | Description                                           | Languages    | Features                                     |
-| :-------------------------- | :---------------------------------------------------- | :----------- | :------------------------------------------- |
+| Action                     | Description                                           | Languages    | Features                                     |
+|:---------------------------|:------------------------------------------------------|:-------------|:---------------------------------------------|
 | ✅ [`php-tests`][php-tests] | Run PHPUnit tests with optional Laravel setup and ... | PHP, Laravel | Caching, Auto-detection, Token auth, Outputs |
 
 #### 🏗️ Build (3 actions)
 
 | Action                            | Description                                           | Languages | Features                                     |
-| :-------------------------------- | :---------------------------------------------------- | :-------- | :------------------------------------------- |
+|:----------------------------------|:------------------------------------------------------|:----------|:---------------------------------------------|
 | 📝 [`csharp-build`][csharp-build] | Builds and tests C# projects.                         | C#, .NET  | Caching, Auto-detection, Token auth, Outputs |
 | 📦 [`docker-build`][docker-build] | Builds a Docker image for multiple architectures w... | Docker    | Caching, Auto-detection, Token auth, Outputs |
 | 📦 [`go-build`][go-build]         | Builds the Go project.                                | Go        | Caching, Auto-detection, Token auth, Outputs |
@@ -96,61 +96,61 @@ This repository contains **25 reusable GitHub Actions** for CI/CD automation.
 #### 🚀 Publishing (3 actions)
 
 | Action                                | Description                                           | Languages    | Features                                     |
-| :------------------------------------ | :---------------------------------------------------- | :----------- | :------------------------------------------- |
+|:--------------------------------------|:------------------------------------------------------|:-------------|:---------------------------------------------|
 | 📦 [`csharp-publish`][csharp-publish] | Publishes a C# project to GitHub Packages.            | C#, .NET     | Caching, Auto-detection, Token auth, Outputs |
 | ☁️ [`docker-publish`][docker-publish] | Simple wrapper to publish Docker images to GitHub ... | Docker       | Token auth, Outputs                          |
 | 📦 [`npm-publish`][npm-publish]       | Publishes the package to the NPM registry with con... | Node.js, npm | Caching, Auto-detection, Token auth, Outputs |
 
 #### 📦 Repository (5 actions)
 
-| Action                                  | Description                                           | Languages                                               | Features                            |
-| :-------------------------------------- | :---------------------------------------------------- | :------------------------------------------------------ | :---------------------------------- |
+| Action                                   | Description                                           | Languages                                               | Features                            |
+|:-----------------------------------------|:------------------------------------------------------|:--------------------------------------------------------|:------------------------------------|
 | 🛡️ [`codeql-analysis`][codeql-analysis] | Run CodeQL security analysis for a single language... | JavaScript, TypeScript, Python, Java, C#, C++, Go, Ruby | Auto-detection, Token auth, Outputs |
 | 🖼️ [`compress-images`][compress-images] | Compress images on demand (workflow_dispatch), and... | Images, PNG, JPEG                                       | Token auth, Outputs                 |
-| 📦 [`release-monthly`][release-monthly] | Creates a release for the current month, increment... | GitHub Actions                                          | Token auth, Outputs                 |
-| 📦 [`stale`][stale]                     | A GitHub Action to close stale issues and pull req... | GitHub Actions                                          | Token auth, Outputs                 |
+| 📦 [`release-monthly`][release-monthly]  | Creates a release for the current month, increment... | GitHub Actions                                          | Token auth, Outputs                 |
+| 📦 [`stale`][stale]                      | A GitHub Action to close stale issues and pull req... | GitHub Actions                                          | Token auth, Outputs                 |
 | 🏷️ [`sync-labels`][sync-labels]         | Sync labels from a YAML file to a GitHub repositor... | YAML, GitHub                                            | Token auth, Outputs                 |
 
 #### 🛡️ Security (1 action)
 
-| Action                              | Description                                           | Languages | Features                     |
-| :---------------------------------- | :---------------------------------------------------- | :-------- | :--------------------------- |
+| Action                               | Description                                           | Languages | Features                     |
+|:-------------------------------------|:------------------------------------------------------|:----------|:-----------------------------|
 | 🛡️ [`security-scan`][security-scan] | Comprehensive security scanning for GitHub Actions... | -         | Caching, Token auth, Outputs |
 
 ### Feature Matrix
 
 | Action                                               | Caching | Auto-detection | Token auth | Outputs |
-| :--------------------------------------------------- | :-----: | :------------: | :--------: | :-----: |
-| [`ansible-lint-fix`][ansible-lint-fix]               |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`biome-lint`][biome-lint]                           |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`codeql-analysis`][codeql-analysis]                 |    -    |       ✅       |     ✅     |   ✅    |
-| [`compress-images`][compress-images]                 |    -    |       -        |     ✅     |   ✅    |
-| [`csharp-build`][csharp-build]                       |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`csharp-lint-check`][csharp-lint-check]             |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`csharp-publish`][csharp-publish]                   |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`docker-build`][docker-build]                       |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`docker-publish`][docker-publish]                   |    -    |       -        |     ✅     |   ✅    |
-| [`eslint-lint`][eslint-lint]                         |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`go-build`][go-build]                               |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`go-lint`][go-lint]                                 |   ✅    |       -        |     ✅     |   ✅    |
-| [`language-version-detect`][language-version-detect] |    -    |       ✅       |     ✅     |   ✅    |
-| [`npm-publish`][npm-publish]                         |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`npm-semantic-release`][npm-semantic-release]       |   ✅    |       ✅       |     -      |   ✅    |
-| [`php-tests`][php-tests]                             |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`pr-lint`][pr-lint]                                 |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`pre-commit`][pre-commit]                           |    -    |       ✅       |     ✅     |   ✅    |
-| [`prettier-lint`][prettier-lint]                     |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`python-lint-fix`][python-lint-fix]                 |   ✅    |       ✅       |     ✅     |   ✅    |
-| [`release-monthly`][release-monthly]                 |    -    |       -        |     ✅     |   ✅    |
-| [`security-scan`][security-scan]                     |   ✅    |       -        |     ✅     |   ✅    |
-| [`stale`][stale]                                     |    -    |       -        |     ✅     |   ✅    |
-| [`sync-labels`][sync-labels]                         |    -    |       -        |     ✅     |   ✅    |
-| [`terraform-lint-fix`][terraform-lint-fix]           |    -    |       -        |     ✅     |   ✅    |
+|:-----------------------------------------------------|:-------:|:--------------:|:----------:|:-------:|
+| [`ansible-lint-fix`][ansible-lint-fix]               |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`biome-lint`][biome-lint]                           |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`codeql-analysis`][codeql-analysis]                 |    -    |       ✅        |     ✅      |    ✅    |
+| [`compress-images`][compress-images]                 |    -    |       -        |     ✅      |    ✅    |
+| [`csharp-build`][csharp-build]                       |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`csharp-lint-check`][csharp-lint-check]             |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`csharp-publish`][csharp-publish]                   |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`docker-build`][docker-build]                       |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`docker-publish`][docker-publish]                   |    -    |       -        |     ✅      |    ✅    |
+| [`eslint-lint`][eslint-lint]                         |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`go-build`][go-build]                               |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`go-lint`][go-lint]                                 |    ✅    |       -        |     ✅      |    ✅    |
+| [`language-version-detect`][language-version-detect] |    -    |       ✅        |     ✅      |    ✅    |
+| [`npm-publish`][npm-publish]                         |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`npm-semantic-release`][npm-semantic-release]       |    ✅    |       ✅        |     -      |    ✅    |
+| [`php-tests`][php-tests]                             |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`pr-lint`][pr-lint]                                 |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`pre-commit`][pre-commit]                           |    -    |       ✅        |     ✅      |    ✅    |
+| [`prettier-lint`][prettier-lint]                     |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`python-lint-fix`][python-lint-fix]                 |    ✅    |       ✅        |     ✅      |    ✅    |
+| [`release-monthly`][release-monthly]                 |    -    |       -        |     ✅      |    ✅    |
+| [`security-scan`][security-scan]                     |    ✅    |       -        |     ✅      |    ✅    |
+| [`stale`][stale]                                     |    -    |       -        |     ✅      |    ✅    |
+| [`sync-labels`][sync-labels]                         |    -    |       -        |     ✅      |    ✅    |
+| [`terraform-lint-fix`][terraform-lint-fix]           |    -    |       -        |     ✅      |    ✅    |
 
 ### Language Support
 
 | Language             | Actions                                                                                                                                                            |
-| :------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|:---------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | .NET                 | [`csharp-build`][csharp-build], [`csharp-lint-check`][csharp-lint-check], [`csharp-publish`][csharp-publish], [`language-version-detect`][language-version-detect] |
 | Ansible              | [`ansible-lint-fix`][ansible-lint-fix]                                                                                                                             |
 | C#                   | [`codeql-analysis`][codeql-analysis], [`csharp-build`][csharp-build], [`csharp-lint-check`][csharp-lint-check], [`csharp-publish`][csharp-publish]                 |

--- a/_tests/README.md
+++ b/_tests/README.md
@@ -363,7 +363,7 @@ End
 ### Options
 
 | Option                | Description                                    |
-| --------------------- | ---------------------------------------------- |
+|-----------------------|------------------------------------------------|
 | `-t, --type TYPE`     | Test type: `unit`, `integration`, `e2e`, `all` |
 | `-a, --action ACTION` | Filter by action name pattern                  |
 | `-j, --jobs JOBS`     | Number of parallel jobs (default: 4)           |

--- a/_tools/docker-testing-tools/README.md
+++ b/_tools/docker-testing-tools/README.md
@@ -17,7 +17,7 @@ jobs:
 ## 📦 Pre-installed Tools
 
 | Tool           | Version         | Purpose                         |
-| -------------- | --------------- | ------------------------------- |
+|----------------|-----------------|---------------------------------|
 | **ShellSpec**  | 0.28.1 (pinned) | Shell script testing framework  |
 | **nektos/act** | 0.2.71 (pinned) | Local GitHub Actions testing    |
 | **TruffleHog** | 3.86.0 (pinned) | Secrets detection               |
@@ -45,7 +45,7 @@ cd _tools/docker-testing-tools
 ## 📊 Performance Benefits
 
 | Workflow Job      | Before | After | Savings        |
-| ----------------- | ------ | ----- | -------------- |
+|-------------------|--------|-------|----------------|
 | Unit Tests        | ~90s   | ~30s  | **60s**        |
 | Integration Tests | ~120s  | ~45s  | **75s**        |
 | Coverage          | ~100s  | ~40s  | **60s**        |

--- a/_validation/README.md
+++ b/_validation/README.md
@@ -14,7 +14,7 @@ self-contained model removes all of that: validation ships _atomically_ with eac
 ## Layout
 
 | File          | Role                                                                                                                  |
-| ------------- | --------------------------------------------------------------------------------------------------------------------- |
+|---------------|-----------------------------------------------------------------------------------------------------------------------|
 | `kit.py`      | Canonical check functions — `CHECKS[type](value) -> error \| None`. Every regex/enum/range is defined here, **once**. |
 | `spec.py`     | Hand-edited map: `SPECS[action] = {"required": [...], "checks": {input: type}}`.                                      |
 | `generate.py` | Inlines the exact source of the checks each action needs into `<action>/validate.py`.                                 |

--- a/ansible-lint-fix/README.md
+++ b/ansible-lint-fix/README.md
@@ -6,21 +6,51 @@ Lints and fixes Ansible playbooks, commits changes, and uploads SARIF report.
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| token | GitHub token for authentication | `false` |  |
-| username | GitHub username for commits | `false` | github-actions |
-| email | GitHub email for commits | `false` | <github-actions@github.com> |
-| max-retries | Maximum number of retry attempts for pip install operations | `false` | 3 |
+| name          | description                                                        | required | default                     |
+|---------------|--------------------------------------------------------------------|----------|-----------------------------|
+| `token`       | <p>GitHub token for authentication</p>                             | `false`  | `""`                        |
+| `username`    | <p>GitHub username for commits</p>                                 | `false`  | `github-actions`            |
+| `email`       | <p>GitHub email for commits</p>                                    | `false`  | `github-actions@github.com` |
+| `max-retries` | <p>Maximum number of retry attempts for pip install operations</p> | `false`  | `3`                         |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| files_changed | Number of files changed by linting |
-| lint_status | Linting status (success/failure) |
-| sarif_path | Path to SARIF report file |
+| name            | description                               |
+|-----------------|-------------------------------------------|
+| `files_changed` | <p>Number of files changed by linting</p> |
+| `lint_status`   | <p>Linting status (success/failure)</p>   |
+| `sarif_path`    | <p>Path to SARIF report file</p>          |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/ansible-lint-fix@vYYYY.MM.DD
+  with:
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    username:
+    # GitHub username for commits
+    #
+    # Required: false
+    # Default: github-actions
+
+    email:
+    # GitHub email for commits
+    #
+    # Required: false
+    # Default: github-actions@github.com
+
+    max-retries:
+    # Maximum number of retry attempts for pip install operations
+    #
+    # Required: false
+    # Default: 3
+```

--- a/ansible-lint-fix/action.yml
+++ b/ansible-lint-fix/action.yml
@@ -63,7 +63,10 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
-        persist-credentials: false
+        # git-auto-commit-action pushes the auto-fix commit using the token that
+        # actions/checkout persists in .git/config; persist-credentials must stay
+        # true or the "Commit Fixes" step cannot authenticate its push.
+        persist-credentials: true # zizmor: ignore[artipacked]
 
     - name: Check for Ansible Files
       id: check-files

--- a/ansible-lint-fix/action.yml
+++ b/ansible-lint-fix/action.yml
@@ -63,6 +63,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Check for Ansible Files
       id: check-files

--- a/biome-lint/README.md
+++ b/biome-lint/README.md
@@ -6,24 +6,66 @@ Run Biome linter in check or fix mode
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| mode | Mode to run (check or fix) | `false` | check |
-| token | GitHub token for authentication | `false` |  |
-| username | GitHub username for commits (fix mode only) | `false` | github-actions |
-| email | GitHub email for commits (fix mode only) | `false` | <github-actions@github.com> |
-| max-retries | Maximum number of retry attempts for npm install operations | `false` | 3 |
-| fail-on-error | Whether to fail the action if linting errors are found (check mode only) | `false` | true |
+| name            | description                                                                     | required | default                     |
+|-----------------|---------------------------------------------------------------------------------|----------|-----------------------------|
+| `mode`          | <p>Mode to run (check or fix)</p>                                               | `false`  | `check`                     |
+| `token`         | <p>GitHub token for authentication</p>                                          | `false`  | `""`                        |
+| `username`      | <p>GitHub username for commits (fix mode only)</p>                              | `false`  | `github-actions`            |
+| `email`         | <p>GitHub email for commits (fix mode only)</p>                                 | `false`  | `github-actions@github.com` |
+| `max-retries`   | <p>Maximum number of retry attempts for npm install operations</p>              | `false`  | `3`                         |
+| `fail-on-error` | <p>Whether to fail the action if linting errors are found (check mode only)</p> | `false`  | `true`                      |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| status | Overall status (success/failure) |
-| errors_count | Number of errors found (check mode only) |
-| warnings_count | Number of warnings found (check mode only) |
-| files_changed | Number of files changed (fix mode only) |
+| name             | description                                       |
+|------------------|---------------------------------------------------|
+| `status`         | <p>Overall status (success/failure)</p>           |
+| `errors_count`   | <p>Number of errors found (check mode only)</p>   |
+| `warnings_count` | <p>Number of warnings found (check mode only)</p> |
+| `files_changed`  | <p>Number of files changed (fix mode only)</p>    |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/biome-lint@vYYYY.MM.DD
+  with:
+    mode:
+    # Mode to run (check or fix)
+    #
+    # Required: false
+    # Default: check
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    username:
+    # GitHub username for commits (fix mode only)
+    #
+    # Required: false
+    # Default: github-actions
+
+    email:
+    # GitHub email for commits (fix mode only)
+    #
+    # Required: false
+    # Default: github-actions@github.com
+
+    max-retries:
+    # Maximum number of retry attempts for npm install operations
+    #
+    # Required: false
+    # Default: 3
+
+    fail-on-error:
+    # Whether to fail the action if linting errors are found (check mode only)
+    #
+    # Required: false
+    # Default: true
+```

--- a/biome-lint/action.yml
+++ b/biome-lint/action.yml
@@ -76,6 +76,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Detect Package Manager
       id: detect-pm

--- a/biome-lint/action.yml
+++ b/biome-lint/action.yml
@@ -76,7 +76,10 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
-        persist-credentials: false
+        # git-auto-commit-action pushes the auto-fix commit using the token that
+        # actions/checkout persists in .git/config; persist-credentials must stay
+        # true or the "Commit Fixes" step cannot authenticate its push.
+        persist-credentials: true # zizmor: ignore[artipacked]
 
     - name: Detect Package Manager
       id: detect-pm

--- a/codeql-analysis/README.md
+++ b/codeql-analysis/README.md
@@ -6,33 +6,135 @@ Run CodeQL security analysis for a single language with configurable query suite
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| language | Language to analyze (javascript, python, actions, java, csharp, cpp, ruby, go, etc.) | `true` |  |
-| queries | Comma-separated list of additional queries to run | `false` |  |
-| packs | Comma-separated list of CodeQL query packs to run | `false` |  |
-| config-file | Path to CodeQL configuration file | `false` |  |
-| config | Configuration passed as a YAML string | `false` |  |
-| build-mode | The build mode for compiled languages (none, manual, autobuild) | `false` |  |
-| source-root | Path of the root source code directory | `false` |  |
-| category | Analysis category (default: /language:<language>) | `false` |  |
-| checkout-ref | Git reference to checkout (default: current ref) | `false` |  |
-| token | GitHub token for API access | `false` | ${{ github.token }} |
-| working-directory | Working directory for the analysis | `false` | . |
-| upload-results | Upload results to GitHub Security tab | `false` | true |
-| ram | Amount of memory in MB that can be used by CodeQL | `false` |  |
-| threads | Number of threads that can be used by CodeQL | `false` |  |
-| output | Path to save SARIF results | `false` | ../results |
-| skip-queries | Build database but skip running queries | `false` | false |
+| name                | description                                                                                 | required | default               |
+|---------------------|---------------------------------------------------------------------------------------------|----------|-----------------------|
+| `language`          | <p>Language to analyze (javascript, python, actions, java, csharp, cpp, ruby, go, etc.)</p> | `true`   | `""`                  |
+| `queries`           | <p>Comma-separated list of additional queries to run</p>                                    | `false`  | `""`                  |
+| `packs`             | <p>Comma-separated list of CodeQL query packs to run</p>                                    | `false`  | `""`                  |
+| `config-file`       | <p>Path to CodeQL configuration file</p>                                                    | `false`  | `""`                  |
+| `config`            | <p>Configuration passed as a YAML string</p>                                                | `false`  | `""`                  |
+| `build-mode`        | <p>The build mode for compiled languages (none, manual, autobuild)</p>                      | `false`  | `""`                  |
+| `source-root`       | <p>Path of the root source code directory</p>                                               | `false`  | `""`                  |
+| `category`          | <p>Analysis category (default: /language:<language>)</p>                                    | `false`  | `""`                  |
+| `checkout-ref`      | <p>Git reference to checkout (default: current ref)</p>                                     | `false`  | `""`                  |
+| `token`             | <p>GitHub token for API access</p>                                                          | `false`  | `${{ github.token }}` |
+| `working-directory` | <p>Working directory for the analysis</p>                                                   | `false`  | `.`                   |
+| `upload-results`    | <p>Upload results to GitHub Security tab</p>                                                | `false`  | `true`                |
+| `ram`               | <p>Amount of memory in MB that can be used by CodeQL</p>                                    | `false`  | `""`                  |
+| `threads`           | <p>Number of threads that can be used by CodeQL</p>                                         | `false`  | `""`                  |
+| `output`            | <p>Path to save SARIF results</p>                                                           | `false`  | `../results`          |
+| `skip-queries`      | <p>Build database but skip running queries</p>                                              | `false`  | `false`               |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| language-analyzed | Language that was analyzed |
-| analysis-category | Category used for the analysis |
-| sarif-file | Path to generated SARIF file |
+| name                | description                           |
+|---------------------|---------------------------------------|
+| `language-analyzed` | <p>Language that was analyzed</p>     |
+| `analysis-category` | <p>Category used for the analysis</p> |
+| `sarif-file`        | <p>Path to generated SARIF file</p>   |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/codeql-analysis@vYYYY.MM.DD
+  with:
+    language:
+    # Language to analyze (javascript, python, actions, java, csharp, cpp, ruby, go, etc.)
+    #
+    # Required: true
+    # Default: ""
+
+    queries:
+    # Comma-separated list of additional queries to run
+    #
+    # Required: false
+    # Default: ""
+
+    packs:
+    # Comma-separated list of CodeQL query packs to run
+    #
+    # Required: false
+    # Default: ""
+
+    config-file:
+    # Path to CodeQL configuration file
+    #
+    # Required: false
+    # Default: ""
+
+    config:
+    # Configuration passed as a YAML string
+    #
+    # Required: false
+    # Default: ""
+
+    build-mode:
+    # The build mode for compiled languages (none, manual, autobuild)
+    #
+    # Required: false
+    # Default: ""
+
+    source-root:
+    # Path of the root source code directory
+    #
+    # Required: false
+    # Default: ""
+
+    category:
+    # Analysis category (default: /language:<language>)
+    #
+    # Required: false
+    # Default: ""
+
+    checkout-ref:
+    # Git reference to checkout (default: current ref)
+    #
+    # Required: false
+    # Default: ""
+
+    token:
+    # GitHub token for API access
+    #
+    # Required: false
+    # Default: ${{ github.token }}
+
+    working-directory:
+    # Working directory for the analysis
+    #
+    # Required: false
+    # Default: .
+
+    upload-results:
+    # Upload results to GitHub Security tab
+    #
+    # Required: false
+    # Default: true
+
+    ram:
+    # Amount of memory in MB that can be used by CodeQL
+    #
+    # Required: false
+    # Default: ""
+
+    threads:
+    # Number of threads that can be used by CodeQL
+    #
+    # Required: false
+    # Default: ""
+
+    output:
+    # Path to save SARIF results
+    #
+    # Required: false
+    # Default: ../results
+
+    skip-queries:
+    # Build database but skip running queries
+    #
+    # Required: false
+    # Default: false
+```

--- a/codeql-analysis/action.yml
+++ b/codeql-analysis/action.yml
@@ -153,6 +153,7 @@ runs:
       with:
         ref: ${{ inputs.checkout-ref || github.sha }}
         token: ${{ inputs.token }}
+        persist-credentials: false
 
     - name: Set analysis category
       id: set-category

--- a/compress-images/README.md
+++ b/compress-images/README.md
@@ -6,23 +6,71 @@ Compress images on demand (workflow_dispatch), and at 11pm every Sunday (schedul
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| token | GitHub token for authentication | `false` | ${{ github.token }} |
-| username | GitHub username for commits | `false` | github-actions |
-| email | GitHub email for commits | `false` | <github-actions@github.com> |
-| working-directory | Directory containing images to compress | `false` | . |
-| image-quality | JPEG compression quality (0-100) | `false` | 85 |
-| png-quality | PNG compression quality (0-100) | `false` | 95 |
-| ignore-paths | Paths to ignore during compression (glob patterns) | `false` | node_modules/**,dist/**,build/** |
+| name                | description                                               | required | default                            |
+|---------------------|-----------------------------------------------------------|----------|------------------------------------|
+| `token`             | <p>GitHub token for authentication</p>                    | `false`  | `${{ github.token }}`              |
+| `username`          | <p>GitHub username for commits</p>                        | `false`  | `github-actions`                   |
+| `email`             | <p>GitHub email for commits</p>                           | `false`  | `github-actions@github.com`        |
+| `working-directory` | <p>Directory containing images to compress</p>            | `false`  | `.`                                |
+| `image-quality`     | <p>JPEG compression quality (0-100)</p>                   | `false`  | `85`                               |
+| `png-quality`       | <p>PNG compression quality (0-100)</p>                    | `false`  | `95`                               |
+| `ignore-paths`      | <p>Paths to ignore during compression (glob patterns)</p> | `false`  | `node_modules/**,dist/**,build/**` |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| images_compressed | Whether any images were compressed (boolean) |
-| compression_report | Markdown report of compression results |
+| name                 | description                                         |
+|----------------------|-----------------------------------------------------|
+| `images_compressed`  | <p>Whether any images were compressed (boolean)</p> |
+| `compression_report` | <p>Markdown report of compression results</p>       |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/compress-images@vYYYY.MM.DD
+  with:
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ${{ github.token }}
+
+    username:
+    # GitHub username for commits
+    #
+    # Required: false
+    # Default: github-actions
+
+    email:
+    # GitHub email for commits
+    #
+    # Required: false
+    # Default: github-actions@github.com
+
+    working-directory:
+    # Directory containing images to compress
+    #
+    # Required: false
+    # Default: .
+
+    image-quality:
+    # JPEG compression quality (0-100)
+    #
+    # Required: false
+    # Default: 85
+
+    png-quality:
+    # PNG compression quality (0-100)
+    #
+    # Required: false
+    # Default: 95
+
+    ignore-paths:
+    # Paths to ignore during compression (glob patterns)
+    #
+    # Required: false
+    # Default: node_modules/**,dist/**,build/**
+```

--- a/compress-images/action.yml
+++ b/compress-images/action.yml
@@ -78,6 +78,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token }}
+        persist-credentials: false
 
     - name: Verify Working Directory
       shell: sh

--- a/csharp-build/README.md
+++ b/csharp-build/README.md
@@ -6,22 +6,46 @@ Builds and tests C# projects.
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| dotnet-version | Version of .NET SDK to use. | `false` |  |
-| max-retries | Maximum number of retry attempts for dotnet restore operations | `false` | 3 |
-| token | GitHub token for authentication | `false` |  |
+| name             | description                                                           | required | default |
+|------------------|-----------------------------------------------------------------------|----------|---------|
+| `dotnet-version` | <p>Version of .NET SDK to use.</p>                                    | `false`  | `""`    |
+| `max-retries`    | <p>Maximum number of retry attempts for dotnet restore operations</p> | `false`  | `3`     |
+| `token`          | <p>GitHub token for authentication</p>                                | `false`  | `""`    |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| build_status | Build completion status (success/failure) |
-| test_status | Test execution status (success/failure/skipped) |
-| dotnet_version | Version of .NET SDK used |
-| artifacts_path | Path to build artifacts |
-| test_results_path | Path to test results |
+| name                | description                                            |
+|---------------------|--------------------------------------------------------|
+| `build_status`      | <p>Build completion status (success/failure)</p>       |
+| `test_status`       | <p>Test execution status (success/failure/skipped)</p> |
+| `dotnet_version`    | <p>Version of .NET SDK used</p>                        |
+| `artifacts_path`    | <p>Path to build artifacts</p>                         |
+| `test_results_path` | <p>Path to test results</p>                            |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/csharp-build@vYYYY.MM.DD
+  with:
+    dotnet-version:
+    # Version of .NET SDK to use.
+    #
+    # Required: false
+    # Default: ""
+
+    max-retries:
+    # Maximum number of retry attempts for dotnet restore operations
+    #
+    # Required: false
+    # Default: 3
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+```

--- a/csharp-build/action.yml
+++ b/csharp-build/action.yml
@@ -62,6 +62,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Detect .NET SDK Version
       id: detect-dotnet-version

--- a/csharp-lint-check/README.md
+++ b/csharp-lint-check/README.md
@@ -6,19 +6,37 @@ Runs linters like StyleCop or dotnet-format for C# code style checks.
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| dotnet-version | Version of .NET SDK to use. | `false` |  |
-| token | GitHub token for authentication | `false` |  |
+| name             | description                            | required | default |
+|------------------|----------------------------------------|----------|---------|
+| `dotnet-version` | <p>Version of .NET SDK to use.</p>     | `false`  | `""`    |
+| `token`          | <p>GitHub token for authentication</p> | `false`  | `""`    |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| lint_status | Overall lint status (success/failure) |
-| errors_count | Number of formatting errors found |
-| warnings_count | Number of formatting warnings found |
+| name             | description                                  |
+|------------------|----------------------------------------------|
+| `lint_status`    | <p>Overall lint status (success/failure)</p> |
+| `errors_count`   | <p>Number of formatting errors found</p>     |
+| `warnings_count` | <p>Number of formatting warnings found</p>   |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/csharp-lint-check@vYYYY.MM.DD
+  with:
+    dotnet-version:
+    # Version of .NET SDK to use.
+    #
+    # Required: false
+    # Default: ""
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+```

--- a/csharp-lint-check/action.yml
+++ b/csharp-lint-check/action.yml
@@ -52,6 +52,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Detect .NET SDK Version
       id: detect-dotnet-version

--- a/csharp-publish/README.md
+++ b/csharp-publish/README.md
@@ -6,21 +6,51 @@ Publishes a C# project to GitHub Packages.
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| dotnet-version | Version of .NET SDK to use. | `false` |  |
-| namespace | GitHub namespace for the package. | `true` | ivuorinen |
-| token | GitHub token with package write permissions | `false` |  |
-| max-retries | Maximum number of retry attempts for dependency restoration | `false` | 3 |
+| name             | description                                                        | required | default     |
+|------------------|--------------------------------------------------------------------|----------|-------------|
+| `dotnet-version` | <p>Version of .NET SDK to use.</p>                                 | `false`  | `""`        |
+| `namespace`      | <p>GitHub namespace for the package.</p>                           | `true`   | `ivuorinen` |
+| `token`          | <p>GitHub token with package write permissions</p>                 | `false`  | `""`        |
+| `max-retries`    | <p>Maximum number of retry attempts for dependency restoration</p> | `false`  | `3`         |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| publish_status | Overall publish status (success/failure) |
-| package_version | Version of the published package |
-| package_url | URL of the published package |
+| name              | description                                     |
+|-------------------|-------------------------------------------------|
+| `publish_status`  | <p>Overall publish status (success/failure)</p> |
+| `package_version` | <p>Version of the published package</p>         |
+| `package_url`     | <p>URL of the published package</p>             |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/csharp-publish@vYYYY.MM.DD
+  with:
+    dotnet-version:
+    # Version of .NET SDK to use.
+    #
+    # Required: false
+    # Default: ""
+
+    namespace:
+    # GitHub namespace for the package.
+    #
+    # Required: true
+    # Default: ivuorinen
+
+    token:
+    # GitHub token with package write permissions
+    #
+    # Required: false
+    # Default: ""
+
+    max-retries:
+    # Maximum number of retry attempts for dependency restoration
+    #
+    # Required: false
+    # Default: 3
+```

--- a/csharp-publish/action.yml
+++ b/csharp-publish/action.yml
@@ -47,12 +47,13 @@ runs:
         API_KEY: ${{ inputs.token || github.token }}
       run: |
         set -eu
-        echo "::add-mask::$API_KEY"
+        printf '::add-mask::%s\n' "$API_KEY"
 
     - name: Checkout Repository
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Validate Inputs
       shell: sh

--- a/docker-build/README.md
+++ b/docker-build/README.md
@@ -6,49 +6,217 @@ Builds a Docker image for multiple architectures with enhanced security and reli
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| image-name | The name of the Docker image to build. Defaults to the repository name. | `false` |  |
-| tag | The tag for the Docker image. Must follow semver or valid Docker tag format. | `true` |  |
-| architectures | Comma-separated list of architectures to build for. | `false` | linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 |
-| dockerfile | Path to the Dockerfile | `false` | Dockerfile |
-| context | Docker build context | `false` | . |
-| build-args | Build arguments in format KEY=VALUE,KEY2=VALUE2 | `false` |  |
-| cache-from | External cache sources (e.g., type=registry,ref=user/app:cache) | `false` |  |
-| push | Whether to push the image after building | `false` | true |
-| max-retries | Maximum number of retry attempts for build and push operations | `false` | 3 |
-| token | GitHub token for authentication | `false` |  |
-| buildx-version | Specific Docker Buildx version to use | `false` | latest |
-| buildkit-version | Specific BuildKit version to use | `false` | v0.11.0 |
-| cache-mode | Cache mode for build layers (min, max, or inline) | `false` | max |
-| build-contexts | Additional build contexts in format name=path,name2=path2 | `false` |  |
-| network | Network mode for build (host, none, or default) | `false` | default |
-| secrets | Build secrets in format id=path,id2=path2 | `false` |  |
-| auto-detect-platforms | Automatically detect and build for all available platforms | `false` | false |
-| platform-build-args | Platform-specific build args in JSON format | `false` |  |
-| parallel-builds | Number of parallel platform builds (0 for auto) | `false` | 0 |
-| cache-export | Export cache destination (e.g., type=local,dest=/tmp/cache) | `false` |  |
-| cache-import | Import cache sources (e.g., type=local,src=/tmp/cache) | `false` |  |
-| dry-run | Perform a dry run without actually building | `false` | false |
-| verbose | Enable verbose logging with platform-specific output | `false` | false |
-| platform-fallback | Continue building other platforms if one fails | `false` | true |
-| scan-image | Scan built image for vulnerabilities | `false` | false |
-| sign-image | Sign the built image with cosign | `false` | false |
-| sbom-format | SBOM format (spdx-json, cyclonedx-json, or syft-json) | `false` | spdx-json |
+| name                    | description                                                                         | required | default                                             |
+|-------------------------|-------------------------------------------------------------------------------------|----------|-----------------------------------------------------|
+| `image-name`            | <p>The name of the Docker image to build. Defaults to the repository name.</p>      | `false`  | `""`                                                |
+| `tag`                   | <p>The tag for the Docker image. Must follow semver or valid Docker tag format.</p> | `true`   | `""`                                                |
+| `architectures`         | <p>Comma-separated list of architectures to build for.</p>                          | `false`  | `linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6` |
+| `dockerfile`            | <p>Path to the Dockerfile</p>                                                       | `false`  | `Dockerfile`                                        |
+| `context`               | <p>Docker build context</p>                                                         | `false`  | `.`                                                 |
+| `build-args`            | <p>Build arguments in format KEY=VALUE,KEY2=VALUE2</p>                              | `false`  | `""`                                                |
+| `cache-from`            | <p>External cache sources (e.g., type=registry,ref=user/app:cache)</p>              | `false`  | `""`                                                |
+| `push`                  | <p>Whether to push the image after building</p>                                     | `false`  | `true`                                              |
+| `max-retries`           | <p>Maximum number of retry attempts for build and push operations</p>               | `false`  | `3`                                                 |
+| `token`                 | <p>GitHub token for authentication</p>                                              | `false`  | `""`                                                |
+| `buildx-version`        | <p>Specific Docker Buildx version to use</p>                                        | `false`  | `latest`                                            |
+| `buildkit-version`      | <p>Specific BuildKit version to use</p>                                             | `false`  | `v0.11.0`                                           |
+| `cache-mode`            | <p>Cache mode for build layers (min, max, or inline)</p>                            | `false`  | `max`                                               |
+| `build-contexts`        | <p>Additional build contexts in format name=path,name2=path2</p>                    | `false`  | `""`                                                |
+| `network`               | <p>Network mode for build (host, none, or default)</p>                              | `false`  | `default`                                           |
+| `secrets`               | <p>Build secrets in format id=path,id2=path2</p>                                    | `false`  | `""`                                                |
+| `auto-detect-platforms` | <p>Automatically detect and build for all available platforms</p>                   | `false`  | `false`                                             |
+| `platform-build-args`   | <p>Platform-specific build args in JSON format</p>                                  | `false`  | `""`                                                |
+| `parallel-builds`       | <p>Number of parallel platform builds (0 for auto)</p>                              | `false`  | `0`                                                 |
+| `cache-export`          | <p>Export cache destination (e.g., type=local,dest=/tmp/cache)</p>                  | `false`  | `""`                                                |
+| `cache-import`          | <p>Import cache sources (e.g., type=local,src=/tmp/cache)</p>                       | `false`  | `""`                                                |
+| `dry-run`               | <p>Perform a dry run without actually building</p>                                  | `false`  | `false`                                             |
+| `verbose`               | <p>Enable verbose logging with platform-specific output</p>                         | `false`  | `false`                                             |
+| `platform-fallback`     | <p>Continue building other platforms if one fails</p>                               | `false`  | `true`                                              |
+| `scan-image`            | <p>Scan built image for vulnerabilities</p>                                         | `false`  | `false`                                             |
+| `sign-image`            | <p>Sign the built image with cosign</p>                                             | `false`  | `false`                                             |
+| `sbom-format`           | <p>SBOM format (spdx-json, cyclonedx-json, or syft-json)</p>                        | `false`  | `spdx-json`                                         |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| image-digest | The digest of the built image |
-| metadata | Build metadata in JSON format |
-| platforms | Successfully built platforms |
-| platform-matrix | Build status per platform in JSON format |
-| build-time | Total build time in seconds |
-| scan-results | Vulnerability scan results if scanning enabled |
-| signature | Image signature if signing enabled |
-| sbom-location | SBOM document location |
+| name              | description                                           |
+|-------------------|-------------------------------------------------------|
+| `image-digest`    | <p>The digest of the built image</p>                  |
+| `metadata`        | <p>Build metadata in JSON format</p>                  |
+| `platforms`       | <p>Successfully built platforms</p>                   |
+| `platform-matrix` | <p>Build status per platform in JSON format</p>       |
+| `build-time`      | <p>Total build time in seconds</p>                    |
+| `scan-results`    | <p>Vulnerability scan results if scanning enabled</p> |
+| `signature`       | <p>Image signature if signing enabled</p>             |
+| `sbom-location`   | <p>SBOM document location</p>                         |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/docker-build@vYYYY.MM.DD
+  with:
+    image-name:
+    # The name of the Docker image to build. Defaults to the repository name.
+    #
+    # Required: false
+    # Default: ""
+
+    tag:
+    # The tag for the Docker image. Must follow semver or valid Docker tag format.
+    #
+    # Required: true
+    # Default: ""
+
+    architectures:
+    # Comma-separated list of architectures to build for.
+    #
+    # Required: false
+    # Default: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+
+    dockerfile:
+    # Path to the Dockerfile
+    #
+    # Required: false
+    # Default: Dockerfile
+
+    context:
+    # Docker build context
+    #
+    # Required: false
+    # Default: .
+
+    build-args:
+    # Build arguments in format KEY=VALUE,KEY2=VALUE2
+    #
+    # Required: false
+    # Default: ""
+
+    cache-from:
+    # External cache sources (e.g., type=registry,ref=user/app:cache)
+    #
+    # Required: false
+    # Default: ""
+
+    push:
+    # Whether to push the image after building
+    #
+    # Required: false
+    # Default: true
+
+    max-retries:
+    # Maximum number of retry attempts for build and push operations
+    #
+    # Required: false
+    # Default: 3
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    buildx-version:
+    # Specific Docker Buildx version to use
+    #
+    # Required: false
+    # Default: latest
+
+    buildkit-version:
+    # Specific BuildKit version to use
+    #
+    # Required: false
+    # Default: v0.11.0
+
+    cache-mode:
+    # Cache mode for build layers (min, max, or inline)
+    #
+    # Required: false
+    # Default: max
+
+    build-contexts:
+    # Additional build contexts in format name=path,name2=path2
+    #
+    # Required: false
+    # Default: ""
+
+    network:
+    # Network mode for build (host, none, or default)
+    #
+    # Required: false
+    # Default: default
+
+    secrets:
+    # Build secrets in format id=path,id2=path2
+    #
+    # Required: false
+    # Default: ""
+
+    auto-detect-platforms:
+    # Automatically detect and build for all available platforms
+    #
+    # Required: false
+    # Default: false
+
+    platform-build-args:
+    # Platform-specific build args in JSON format
+    #
+    # Required: false
+    # Default: ""
+
+    parallel-builds:
+    # Number of parallel platform builds (0 for auto)
+    #
+    # Required: false
+    # Default: 0
+
+    cache-export:
+    # Export cache destination (e.g., type=local,dest=/tmp/cache)
+    #
+    # Required: false
+    # Default: ""
+
+    cache-import:
+    # Import cache sources (e.g., type=local,src=/tmp/cache)
+    #
+    # Required: false
+    # Default: ""
+
+    dry-run:
+    # Perform a dry run without actually building
+    #
+    # Required: false
+    # Default: false
+
+    verbose:
+    # Enable verbose logging with platform-specific output
+    #
+    # Required: false
+    # Default: false
+
+    platform-fallback:
+    # Continue building other platforms if one fails
+    #
+    # Required: false
+    # Default: true
+
+    scan-image:
+    # Scan built image for vulnerabilities
+    #
+    # Required: false
+    # Default: false
+
+    sign-image:
+    # Sign the built image with cosign
+    #
+    # Required: false
+    # Default: false
+
+    sbom-format:
+    # SBOM format (spdx-json, cyclonedx-json, or syft-json)
+    #
+    # Required: false
+    # Default: spdx-json
+```

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -144,6 +144,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Validate Inputs
       shell: sh

--- a/docker-publish/README.md
+++ b/docker-publish/README.md
@@ -6,29 +6,101 @@ Simple wrapper to publish Docker images to GitHub Packages and/or Docker Hub
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| registry | Registry to publish to (dockerhub, github, or both) | `false` | both |
-| image-name | Docker image name (defaults to repository name) | `false` |  |
-| tags | Comma-separated list of tags (e.g., latest,v1.0.0) | `false` | latest |
-| platforms | Platforms to build for (comma-separated) | `false` | linux/amd64,linux/arm64 |
-| context | Build context path | `false` | . |
-| dockerfile | Path to Dockerfile | `false` | Dockerfile |
-| build-args | Build arguments (newline-separated KEY=VALUE pairs) | `false` |  |
-| push | Whether to push the image | `false` | true |
-| token | GitHub token for authentication (for GitHub registry) | `false` |  |
-| dockerhub-username | Docker Hub username (required if publishing to Docker Hub) | `false` |  |
-| dockerhub-token | Docker Hub token (required if publishing to Docker Hub) | `false` |  |
+| name                 | description                                                       | required | default                   |
+|----------------------|-------------------------------------------------------------------|----------|---------------------------|
+| `registry`           | <p>Registry to publish to (dockerhub, github, or both)</p>        | `false`  | `both`                    |
+| `image-name`         | <p>Docker image name (defaults to repository name)</p>            | `false`  | `""`                      |
+| `tags`               | <p>Comma-separated list of tags (e.g., latest,v1.0.0)</p>         | `false`  | `latest`                  |
+| `platforms`          | <p>Platforms to build for (comma-separated)</p>                   | `false`  | `linux/amd64,linux/arm64` |
+| `context`            | <p>Build context path</p>                                         | `false`  | `.`                       |
+| `dockerfile`         | <p>Path to Dockerfile</p>                                         | `false`  | `Dockerfile`              |
+| `build-args`         | <p>Build arguments (newline-separated KEY=VALUE pairs)</p>        | `false`  | `""`                      |
+| `push`               | <p>Whether to push the image</p>                                  | `false`  | `true`                    |
+| `token`              | <p>GitHub token for authentication (for GitHub registry)</p>      | `false`  | `""`                      |
+| `dockerhub-username` | <p>Docker Hub username (required if publishing to Docker Hub)</p> | `false`  | `""`                      |
+| `dockerhub-token`    | <p>Docker Hub token (required if publishing to Docker Hub)</p>    | `false`  | `""`                      |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| image-name | Full image name with registry |
-| tags | Tags that were published |
-| digest | Image digest |
-| metadata | Build metadata |
+| name         | description                          |
+|--------------|--------------------------------------|
+| `image-name` | <p>Full image name with registry</p> |
+| `tags`       | <p>Tags that were published</p>      |
+| `digest`     | <p>Image digest</p>                  |
+| `metadata`   | <p>Build metadata</p>                |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/docker-publish@vYYYY.MM.DD
+  with:
+    registry:
+    # Registry to publish to (dockerhub, github, or both)
+    #
+    # Required: false
+    # Default: both
+
+    image-name:
+    # Docker image name (defaults to repository name)
+    #
+    # Required: false
+    # Default: ""
+
+    tags:
+    # Comma-separated list of tags (e.g., latest,v1.0.0)
+    #
+    # Required: false
+    # Default: latest
+
+    platforms:
+    # Platforms to build for (comma-separated)
+    #
+    # Required: false
+    # Default: linux/amd64,linux/arm64
+
+    context:
+    # Build context path
+    #
+    # Required: false
+    # Default: .
+
+    dockerfile:
+    # Path to Dockerfile
+    #
+    # Required: false
+    # Default: Dockerfile
+
+    build-args:
+    # Build arguments (newline-separated KEY=VALUE pairs)
+    #
+    # Required: false
+    # Default: ""
+
+    push:
+    # Whether to push the image
+    #
+    # Required: false
+    # Default: true
+
+    token:
+    # GitHub token for authentication (for GitHub registry)
+    #
+    # Required: false
+    # Default: ""
+
+    dockerhub-username:
+    # Docker Hub username (required if publishing to Docker Hub)
+    #
+    # Required: false
+    # Default: ""
+
+    dockerhub-token:
+    # Docker Hub token (required if publishing to Docker Hub)
+    #
+    # Required: false
+    # Default: ""
+```

--- a/docs/audit/nitpicker-findings.md
+++ b/docs/audit/nitpicker-findings.md
@@ -1,11 +1,11 @@
 # Nitpicker Findings
 
 Generated: 2026-04-30
-Last validated: 2026-06-05 (Pass 22 — validate-inputs deep audit; fixed N-125..N-132, N-134, N-135; invalid N-133; all open findings resolved)
+Last validated: 2026-06-15 (Pass 23 — chore/updates branch review; fixed N-136, the persist-credentials regression in 7 auto-commit fix-actions; all open findings resolved)
 
 ## Summary
 
-- Total: 135 | Open: 0 | Fixed: 132 | Invalid: 3
+- Total: 136 | Open: 0 | Fixed: 133 | Invalid: 3
 
 ## Open Findings
 
@@ -34,6 +34,37 @@ via per-action migration in commits 3dcf7cb..2191252 + test-fixup 03adba5. Every
 that accepts inputs now delegates to `ivuorinen/actions/validate-inputs@5cc7373a`.
 
 ## Fixed
+
+### Pass 23 — 2026-06-15
+
+#### [N-136] `persist-credentials: false` breaks git-auto-commit push in 7 fix-actions
+
+Category: correctness
+Area: ansible-lint-fix, biome-lint, eslint-lint, pre-commit, prettier-lint, python-lint-fix, terraform-lint-fix (action.yml checkout step)
+Problem: Commit `9f6d2d8` set `persist-credentials: false` on every `actions/checkout` step
+across the repo as a security hardening. Seven of those actions end with a
+`stefanzweifel/git-auto-commit-action` step that commits and pushes auto-fix results.
+That action pushes using the token `actions/checkout` writes into `.git/config`; with
+`persist-credentials: false` the post-checkout step deletes that auth header, so the
+push has no credentials.
+Evidence: git-auto-commit-action README (master) states verbatim: "Value already defaults
+to true, but `persist-credentials` is required to push new commits to the repository"
+and shows `persist-credentials: true` in its canonical example. The action exposes no
+env-token / push-token alternative — the persisted checkout credential is the only auth
+path. All 7 actions had `persist-credentials: false` + an unconfigured auto-commit step.
+Impact: Whenever auto-fix is enabled and the linter changes files, the "Commit Fixes"
+step fails to authenticate (`fatal: could not read Username` / 403) and the action fails
+— the core feature of every `-fix` action is broken for all external consumers.
+Fix: Set `persist-credentials: true` on the checkout step of the 7 auto-commit actions,
+with a comment explaining the requirement and a `# zizmor: ignore[artipacked]` directive
+documenting the accepted, functionally-required credential persistence. The ~18 actions
+that never push keep `persist-credentials: false`. Verified: `action-validator` passes on
+all 7; no `persist-credentials: false` remains in them.
+Notes: No CI gate regressed — zizmor is not wired into CI (no config, not in workflows,
+pre-commit, or security-scan); the security gate is actionlint + trivy + gitleaks, none
+of which inspect persist-credentials. No integration test exercises the auto-commit push,
+which is why the regression was not caught (coverage gap noted; an end-to-end push test
+needs a throwaway remote, so it is tracked here rather than opened as a separate finding).
 
 ### Pass 22 — 2026-06-05
 

--- a/eslint-lint/README.md
+++ b/eslint-lint/README.md
@@ -6,35 +6,125 @@ Run ESLint in check or fix mode with advanced configuration and reporting
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| mode | Mode to run (check or fix) | `false` | check |
-| working-directory | Directory containing files to lint | `false` | . |
-| eslint-version | ESLint version to use | `false` | latest |
-| config-file | Path to ESLint config file | `false` | .eslintrc |
-| ignore-file | Path to ESLint ignore file | `false` | .eslintignore |
-| file-extensions | File extensions to lint (comma-separated) | `false` | .js,.jsx,.ts,.tsx |
-| cache | Enable ESLint caching | `false` | true |
-| max-warnings | Maximum number of warnings allowed (check mode only) | `false` | 0 |
-| fail-on-error | Fail workflow if issues are found (check mode only) | `false` | true |
-| report-format | Output format for check mode (stylish, json, sarif) | `false` | sarif |
-| max-retries | Maximum number of retry attempts | `false` | 3 |
-| token | GitHub token for authentication | `false` |  |
-| username | GitHub username for commits (fix mode only) | `false` | github-actions |
-| email | GitHub email for commits (fix mode only) | `false` | <github-actions@github.com> |
+| name                | description                                                 | required | default                     |
+|---------------------|-------------------------------------------------------------|----------|-----------------------------|
+| `mode`              | <p>Mode to run (check or fix)</p>                           | `false`  | `check`                     |
+| `working-directory` | <p>Directory containing files to lint</p>                   | `false`  | `.`                         |
+| `eslint-version`    | <p>ESLint version to use</p>                                | `false`  | `latest`                    |
+| `config-file`       | <p>Path to ESLint config file</p>                           | `false`  | `.eslintrc`                 |
+| `ignore-file`       | <p>Path to ESLint ignore file</p>                           | `false`  | `.eslintignore`             |
+| `file-extensions`   | <p>File extensions to lint (comma-separated)</p>            | `false`  | `.js,.jsx,.ts,.tsx`         |
+| `cache`             | <p>Enable ESLint caching</p>                                | `false`  | `true`                      |
+| `max-warnings`      | <p>Maximum number of warnings allowed (check mode only)</p> | `false`  | `0`                         |
+| `fail-on-error`     | <p>Fail workflow if issues are found (check mode only)</p>  | `false`  | `true`                      |
+| `report-format`     | <p>Output format for check mode (stylish, json, sarif)</p>  | `false`  | `sarif`                     |
+| `max-retries`       | <p>Maximum number of retry attempts</p>                     | `false`  | `3`                         |
+| `token`             | <p>GitHub token for authentication</p>                      | `false`  | `""`                        |
+| `username`          | <p>GitHub username for commits (fix mode only)</p>          | `false`  | `github-actions`            |
+| `email`             | <p>GitHub email for commits (fix mode only)</p>             | `false`  | `github-actions@github.com` |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| status | Overall status (success/failure) |
-| error-count | Number of errors found (check mode only) |
-| warning-count | Number of warnings found (check mode only) |
-| sarif-file | Path to SARIF report file (check mode only) |
-| files-checked | Number of files checked (check mode only) |
-| files-changed | Number of files changed (fix mode only) |
-| errors-fixed | Number of errors fixed (fix mode only) |
+| name            | description                                        |
+|-----------------|----------------------------------------------------|
+| `status`        | <p>Overall status (success/failure)</p>            |
+| `error-count`   | <p>Number of errors found (check mode only)</p>    |
+| `warning-count` | <p>Number of warnings found (check mode only)</p>  |
+| `sarif-file`    | <p>Path to SARIF report file (check mode only)</p> |
+| `files-checked` | <p>Number of files checked (check mode only)</p>   |
+| `files-changed` | <p>Number of files changed (fix mode only)</p>     |
+| `errors-fixed`  | <p>Number of errors fixed (fix mode only)</p>      |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/eslint-lint@vYYYY.MM.DD
+  with:
+    mode:
+    # Mode to run (check or fix)
+    #
+    # Required: false
+    # Default: check
+
+    working-directory:
+    # Directory containing files to lint
+    #
+    # Required: false
+    # Default: .
+
+    eslint-version:
+    # ESLint version to use
+    #
+    # Required: false
+    # Default: latest
+
+    config-file:
+    # Path to ESLint config file
+    #
+    # Required: false
+    # Default: .eslintrc
+
+    ignore-file:
+    # Path to ESLint ignore file
+    #
+    # Required: false
+    # Default: .eslintignore
+
+    file-extensions:
+    # File extensions to lint (comma-separated)
+    #
+    # Required: false
+    # Default: .js,.jsx,.ts,.tsx
+
+    cache:
+    # Enable ESLint caching
+    #
+    # Required: false
+    # Default: true
+
+    max-warnings:
+    # Maximum number of warnings allowed (check mode only)
+    #
+    # Required: false
+    # Default: 0
+
+    fail-on-error:
+    # Fail workflow if issues are found (check mode only)
+    #
+    # Required: false
+    # Default: true
+
+    report-format:
+    # Output format for check mode (stylish, json, sarif)
+    #
+    # Required: false
+    # Default: sarif
+
+    max-retries:
+    # Maximum number of retry attempts
+    #
+    # Required: false
+    # Default: 3
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    username:
+    # GitHub username for commits (fix mode only)
+    #
+    # Required: false
+    # Default: github-actions
+
+    email:
+    # GitHub email for commits (fix mode only)
+    #
+    # Required: false
+    # Default: github-actions@github.com
+```

--- a/eslint-lint/action.yml
+++ b/eslint-lint/action.yml
@@ -125,6 +125,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Detect Package Manager
       id: detect-pm

--- a/eslint-lint/action.yml
+++ b/eslint-lint/action.yml
@@ -125,7 +125,10 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
-        persist-credentials: false
+        # git-auto-commit-action pushes the auto-fix commit using the token that
+        # actions/checkout persists in .git/config; persist-credentials must stay
+        # true or the "Commit Fixes" step cannot authenticate its push.
+        persist-credentials: true # zizmor: ignore[artipacked]
 
     - name: Detect Package Manager
       id: detect-pm

--- a/go-build/README.md
+++ b/go-build/README.md
@@ -6,23 +6,53 @@ Builds the Go project.
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| go-version | Go version to use. | `false` |  |
-| destination | Build destination directory. | `false` | ./bin |
-| max-retries | Maximum number of retry attempts for go mod download operations | `false` | 3 |
-| token | GitHub token for authentication | `false` |  |
+| name          | description                                                            | required | default |
+|---------------|------------------------------------------------------------------------|----------|---------|
+| `go-version`  | <p>Go version to use.</p>                                              | `false`  | `""`    |
+| `destination` | <p>Build destination directory.</p>                                    | `false`  | `./bin` |
+| `max-retries` | <p>Maximum number of retry attempts for go mod download operations</p> | `false`  | `3`     |
+| `token`       | <p>GitHub token for authentication</p>                                 | `false`  | `""`    |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| build_status | Build completion status (success/failure) |
-| test_status | Test execution status (success/failure/skipped) |
-| go_version | Version of Go used |
-| binary_path | Path to built binaries |
-| coverage_path | Path to coverage report |
+| name            | description                                            |
+|-----------------|--------------------------------------------------------|
+| `build_status`  | <p>Build completion status (success/failure)</p>       |
+| `test_status`   | <p>Test execution status (success/failure/skipped)</p> |
+| `go_version`    | <p>Version of Go used</p>                              |
+| `binary_path`   | <p>Path to built binaries</p>                          |
+| `coverage_path` | <p>Path to coverage report</p>                         |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/go-build@vYYYY.MM.DD
+  with:
+    go-version:
+    # Go version to use.
+    #
+    # Required: false
+    # Default: ""
+
+    destination:
+    # Build destination directory.
+    #
+    # Required: false
+    # Default: ./bin
+
+    max-retries:
+    # Maximum number of retry attempts for go mod download operations
+    #
+    # Required: false
+    # Default: 3
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+```

--- a/go-build/action.yml
+++ b/go-build/action.yml
@@ -67,6 +67,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Detect Go Version
       id: detect-go-version

--- a/go-lint/README.md
+++ b/go-lint/README.md
@@ -6,32 +6,122 @@ Run golangci-lint with advanced configuration, caching, and reporting
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| working-directory | Directory containing Go files | `false` | . |
-| golangci-lint-version | Version of golangci-lint to use | `false` | latest |
-| go-version | Go version to use | `false` | stable |
-| config-file | Path to golangci-lint config file | `false` | .golangci.yml |
-| timeout | Timeout for analysis (e.g., 5m, 1h) | `false` | 5m |
-| cache | Enable golangci-lint caching | `false` | true |
-| fail-on-error | Fail workflow if issues are found | `false` | true |
-| report-format | Output format (json, sarif, github-actions) | `false` | sarif |
-| max-retries | Maximum number of retry attempts | `false` | 3 |
-| only-new-issues | Report only new issues since main branch | `false` | true |
-| disable-all | Disable all linters (useful with --enable-*) | `false` | false |
-| enable-linters | Comma-separated list of linters to enable | `false` |  |
-| disable-linters | Comma-separated list of linters to disable | `false` |  |
-| token | GitHub token for authentication | `false` |  |
+| name                    | description                                          | required | default         |
+|-------------------------|------------------------------------------------------|----------|-----------------|
+| `working-directory`     | <p>Directory containing Go files</p>                 | `false`  | `.`             |
+| `golangci-lint-version` | <p>Version of golangci-lint to use</p>               | `false`  | `latest`        |
+| `go-version`            | <p>Go version to use</p>                             | `false`  | `stable`        |
+| `config-file`           | <p>Path to golangci-lint config file</p>             | `false`  | `.golangci.yml` |
+| `timeout`               | <p>Timeout for analysis (e.g., 5m, 1h)</p>           | `false`  | `5m`            |
+| `cache`                 | <p>Enable golangci-lint caching</p>                  | `false`  | `true`          |
+| `fail-on-error`         | <p>Fail workflow if issues are found</p>             | `false`  | `true`          |
+| `report-format`         | <p>Output format (json, sarif, github-actions)</p>   | `false`  | `sarif`         |
+| `max-retries`           | <p>Maximum number of retry attempts</p>              | `false`  | `3`             |
+| `only-new-issues`       | <p>Report only new issues since main branch</p>      | `false`  | `true`          |
+| `disable-all`           | <p>Disable all linters (useful with --enable-\*)</p> | `false`  | `false`         |
+| `enable-linters`        | <p>Comma-separated list of linters to enable</p>     | `false`  | `""`            |
+| `disable-linters`       | <p>Comma-separated list of linters to disable</p>    | `false`  | `""`            |
+| `token`                 | <p>GitHub token for authentication</p>               | `false`  | `""`            |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| error-count | Number of errors found |
-| sarif-file | Path to SARIF report file |
-| cache-hit | Indicates if there was a cache hit |
-| analyzed-files | Number of files analyzed |
+| name             | description                               |
+|------------------|-------------------------------------------|
+| `error-count`    | <p>Number of errors found</p>             |
+| `sarif-file`     | <p>Path to SARIF report file</p>          |
+| `cache-hit`      | <p>Indicates if there was a cache hit</p> |
+| `analyzed-files` | <p>Number of files analyzed</p>           |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/go-lint@vYYYY.MM.DD
+  with:
+    working-directory:
+    # Directory containing Go files
+    #
+    # Required: false
+    # Default: .
+
+    golangci-lint-version:
+    # Version of golangci-lint to use
+    #
+    # Required: false
+    # Default: latest
+
+    go-version:
+    # Go version to use
+    #
+    # Required: false
+    # Default: stable
+
+    config-file:
+    # Path to golangci-lint config file
+    #
+    # Required: false
+    # Default: .golangci.yml
+
+    timeout:
+    # Timeout for analysis (e.g., 5m, 1h)
+    #
+    # Required: false
+    # Default: 5m
+
+    cache:
+    # Enable golangci-lint caching
+    #
+    # Required: false
+    # Default: true
+
+    fail-on-error:
+    # Fail workflow if issues are found
+    #
+    # Required: false
+    # Default: true
+
+    report-format:
+    # Output format (json, sarif, github-actions)
+    #
+    # Required: false
+    # Default: sarif
+
+    max-retries:
+    # Maximum number of retry attempts
+    #
+    # Required: false
+    # Default: 3
+
+    only-new-issues:
+    # Report only new issues since main branch
+    #
+    # Required: false
+    # Default: true
+
+    disable-all:
+    # Disable all linters (useful with --enable-*)
+    #
+    # Required: false
+    # Default: false
+
+    enable-linters:
+    # Comma-separated list of linters to enable
+    #
+    # Required: false
+    # Default: ""
+
+    disable-linters:
+    # Comma-separated list of linters to disable
+    #
+    # Required: false
+    # Default: ""
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+```

--- a/go-lint/action.yml
+++ b/go-lint/action.yml
@@ -120,6 +120,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Cache golangci-lint
       id: cache

--- a/language-version-detect/README.md
+++ b/language-version-detect/README.md
@@ -6,19 +6,43 @@ DEPRECATED: This action is deprecated. Inline version detection directly in your
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| language | Language to detect version for (php, python, go, dotnet) | `true` |  |
-| default-version | Default version to use if no version is detected | `false` |  |
-| token | GitHub token for authentication | `false` |  |
+| name              | description                                                     | required | default |
+|-------------------|-----------------------------------------------------------------|----------|---------|
+| `language`        | <p>Language to detect version for (php, python, go, dotnet)</p> | `true`   | `""`    |
+| `default-version` | <p>Default version to use if no version is detected</p>         | `false`  | `""`    |
+| `token`           | <p>GitHub token for authentication</p>                          | `false`  | `""`    |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| detected-version | Detected or default language version |
-| package-manager | Detected package manager (python: pip/poetry/pipenv, php: composer) |
+| name               | description                                                                |
+|--------------------|----------------------------------------------------------------------------|
+| `detected-version` | <p>Detected or default language version</p>                                |
+| `package-manager`  | <p>Detected package manager (python: pip/poetry/pipenv, php: composer)</p> |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/language-version-detect@vYYYY.MM.DD
+  with:
+    language:
+    # Language to detect version for (php, python, go, dotnet)
+    #
+    # Required: true
+    # Default: ""
+
+    default-version:
+    # Default version to use if no version is detected
+    #
+    # Required: false
+    # Default: ""
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+```

--- a/language-version-detect/action.yml
+++ b/language-version-detect/action.yml
@@ -76,6 +76,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Parse Language Version
       id: parse-version

--- a/npm-publish/README.md
+++ b/npm-publish/README.md
@@ -6,22 +6,58 @@ Publishes the package to the NPM registry with configurable scope and registry U
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| npm_token | NPM token. | `true` |  |
-| registry-url | Registry URL for publishing. | `false` | <https://registry.npmjs.org/> |
-| scope | Package scope to use. | `false` | @ivuorinen |
-| package-version | The version to publish. | `false` | ${{ github.event.release.tag_name }} |
-| token | GitHub token for authentication | `false` |  |
+| name              | description                            | required | default                                |
+|-------------------|----------------------------------------|----------|----------------------------------------|
+| `npm_token`       | <p>NPM token.</p>                      | `true`   | `""`                                   |
+| `registry-url`    | <p>Registry URL for publishing.</p>    | `false`  | `https://registry.npmjs.org/`          |
+| `scope`           | <p>Package scope to use.</p>           | `false`  | `@ivuorinen`                           |
+| `package-version` | <p>The version to publish.</p>         | `false`  | `${{ github.event.release.tag_name }}` |
+| `token`           | <p>GitHub token for authentication</p> | `false`  | `""`                                   |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| registry-url | Registry URL for publishing. |
-| scope | Package scope to use. |
-| package-version | The version to publish. |
+| name              | description                         |
+|-------------------|-------------------------------------|
+| `registry-url`    | <p>Registry URL for publishing.</p> |
+| `scope`           | <p>Package scope to use.</p>        |
+| `package-version` | <p>The version to publish.</p>      |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/npm-publish@vYYYY.MM.DD
+  with:
+    npm_token:
+    # NPM token.
+    #
+    # Required: true
+    # Default: ""
+
+    registry-url:
+    # Registry URL for publishing.
+    #
+    # Required: false
+    # Default: https://registry.npmjs.org/
+
+    scope:
+    # Package scope to use.
+    #
+    # Required: false
+    # Default: @ivuorinen
+
+    package-version:
+    # The version to publish.
+    #
+    # Required: false
+    # Default: ${{ github.event.release.tag_name }}
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+```

--- a/npm-publish/action.yml
+++ b/npm-publish/action.yml
@@ -75,6 +75,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Validate Checkout
       shell: sh

--- a/npm-semantic-release/README.md
+++ b/npm-semantic-release/README.md
@@ -6,22 +6,64 @@ Runs semantic-release for automated npm versioning and publishing with OIDC prov
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| npm_token | NPM token for publishing. | `true` |  |
-| github_token | GitHub token for creating releases, tags, and PR comments. | `false` | ${{ github.token }} |
-| scope | Package scope to use. | `false` | @ivuorinen |
-| registry-url | Registry URL for publishing. | `false` | <https://registry.npmjs.org/> |
-| node-version | Node.js version to use when .nvmrc is not present. | `false` | 24 |
-| extra_plugins | Extra semantic-release plugins (pipe-separated). | `false` | conventional-changelog-conventionalcommits@^9.3.1 |
+| name            | description                                                       | required | default                                             |
+|-----------------|-------------------------------------------------------------------|----------|-----------------------------------------------------|
+| `npm_token`     | <p>NPM token for publishing.</p>                                  | `true`   | `""`                                                |
+| `github_token`  | <p>GitHub token for creating releases, tags, and PR comments.</p> | `false`  | `${{ github.token }}`                               |
+| `scope`         | <p>Package scope to use.</p>                                      | `false`  | `@ivuorinen`                                        |
+| `registry-url`  | <p>Registry URL for publishing.</p>                               | `false`  | `https://registry.npmjs.org/`                       |
+| `node-version`  | <p>Node.js version to use when .nvmrc is not present.</p>         | `false`  | `24`                                                |
+| `extra_plugins` | <p>Extra semantic-release plugins (pipe-separated).</p>           | `false`  | `conventional-changelog-conventionalcommits@^9.3.1` |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| new-release-published | Whether a new release was published. |
-| new-release-version | The new release version, if published. |
+| name                    | description                                   |
+|-------------------------|-----------------------------------------------|
+| `new-release-published` | <p>Whether a new release was published.</p>   |
+| `new-release-version`   | <p>The new release version, if published.</p> |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/npm-semantic-release@vYYYY.MM.DD
+  with:
+    npm_token:
+    # NPM token for publishing.
+    #
+    # Required: true
+    # Default: ""
+
+    github_token:
+    # GitHub token for creating releases, tags, and PR comments.
+    #
+    # Required: false
+    # Default: ${{ github.token }}
+
+    scope:
+    # Package scope to use.
+    #
+    # Required: false
+    # Default: @ivuorinen
+
+    registry-url:
+    # Registry URL for publishing.
+    #
+    # Required: false
+    # Default: https://registry.npmjs.org/
+
+    node-version:
+    # Node.js version to use when .nvmrc is not present.
+    #
+    # Required: false
+    # Default: 24
+
+    extra_plugins:
+    # Extra semantic-release plugins (pipe-separated).
+    #
+    # Required: false
+    # Default: conventional-changelog-conventionalcommits@^9.3.1
+```

--- a/npm-semantic-release/action.yml
+++ b/npm-semantic-release/action.yml
@@ -64,6 +64,7 @@ runs:
       with:
         token: ${{ inputs.github_token }}
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Validate Inputs
       shell: sh

--- a/php-tests/README.md
+++ b/php-tests/README.md
@@ -6,30 +6,90 @@ Run PHPUnit tests with optional Laravel setup and Composer dependency management
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| framework | Framework detection mode (auto=detect Laravel via artisan, laravel=force Laravel, generic=no framework) | `false` | auto |
-| php-version | PHP Version to use (latest, 8.4, 8.3, etc.) | `false` | latest |
-| extensions | PHP extensions to install (comma-separated) | `false` | mbstring, intl, json, pdo_sqlite, sqlite3 |
-| coverage | Code-coverage driver (none, xdebug, pcov) | `false` | none |
-| composer-args | Arguments to pass to Composer install | `false` | --no-progress --prefer-dist --optimize-autoloader |
-| max-retries | Maximum number of retry attempts for Composer commands | `false` | 3 |
-| token | GitHub token for authentication | `false` |  |
-| username | GitHub username for commits | `false` | github-actions |
-| email | GitHub email for commits | `false` | <github-actions@github.com> |
+| name            | description                                                                                                    | required | default                                             |
+|-----------------|----------------------------------------------------------------------------------------------------------------|----------|-----------------------------------------------------|
+| `framework`     | <p>Framework detection mode (auto=detect Laravel via artisan, laravel=force Laravel, generic=no framework)</p> | `false`  | `auto`                                              |
+| `php-version`   | <p>PHP Version to use (latest, 8.4, 8.3, etc.)</p>                                                             | `false`  | `latest`                                            |
+| `extensions`    | <p>PHP extensions to install (comma-separated)</p>                                                             | `false`  | `mbstring, intl, json, pdo_sqlite, sqlite3`         |
+| `coverage`      | <p>Code-coverage driver (none, xdebug, pcov)</p>                                                               | `false`  | `none`                                              |
+| `composer-args` | <p>Arguments to pass to Composer install</p>                                                                   | `false`  | `--no-progress --prefer-dist --optimize-autoloader` |
+| `max-retries`   | <p>Maximum number of retry attempts for Composer commands</p>                                                  | `false`  | `3`                                                 |
+| `token`         | <p>GitHub token for authentication</p>                                                                         | `false`  | `""`                                                |
+| `username`      | <p>GitHub username for commits</p>                                                                             | `false`  | `github-actions`                                    |
+| `email`         | <p>GitHub email for commits</p>                                                                                | `false`  | `github-actions@github.com`                         |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| framework | Detected framework (laravel or generic) |
-| php-version | The PHP version that was setup |
-| composer-version | Installed Composer version |
-| cache-hit | Indicates if there was a cache hit |
-| test-status | Test execution status (success/failure) |
-| tests-run | Number of tests executed |
-| tests-passed | Number of tests passed |
+| name               | description                                    |
+|--------------------|------------------------------------------------|
+| `framework`        | <p>Detected framework (laravel or generic)</p> |
+| `php-version`      | <p>The PHP version that was setup</p>          |
+| `composer-version` | <p>Installed Composer version</p>              |
+| `cache-hit`        | <p>Indicates if there was a cache hit</p>      |
+| `test-status`      | <p>Test execution status (success/failure)</p> |
+| `tests-run`        | <p>Number of tests executed</p>                |
+| `tests-passed`     | <p>Number of tests passed</p>                  |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/php-tests@vYYYY.MM.DD
+  with:
+    framework:
+    # Framework detection mode (auto=detect Laravel via artisan, laravel=force Laravel, generic=no framework)
+    #
+    # Required: false
+    # Default: auto
+
+    php-version:
+    # PHP Version to use (latest, 8.4, 8.3, etc.)
+    #
+    # Required: false
+    # Default: latest
+
+    extensions:
+    # PHP extensions to install (comma-separated)
+    #
+    # Required: false
+    # Default: mbstring, intl, json, pdo_sqlite, sqlite3
+
+    coverage:
+    # Code-coverage driver (none, xdebug, pcov)
+    #
+    # Required: false
+    # Default: none
+
+    composer-args:
+    # Arguments to pass to Composer install
+    #
+    # Required: false
+    # Default: --no-progress --prefer-dist --optimize-autoloader
+
+    max-retries:
+    # Maximum number of retry attempts for Composer commands
+    #
+    # Required: false
+    # Default: 3
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    username:
+    # GitHub username for commits
+    #
+    # Required: false
+    # Default: github-actions
+
+    email:
+    # GitHub email for commits
+    #
+    # Required: false
+    # Default: github-actions@github.com
+```

--- a/php-tests/action.yml
+++ b/php-tests/action.yml
@@ -109,6 +109,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Detect Framework
       id: detect-framework
@@ -253,7 +254,7 @@ runs:
 
     - name: Setup PHP
       id: setup-php
-      uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ steps.detect-php-version.outputs.detected-version }}
         extensions: ${{ inputs.extensions }}

--- a/pr-lint/README.md
+++ b/pr-lint/README.md
@@ -6,19 +6,43 @@ Runs MegaLinter against pull requests
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| token | GitHub token for authentication | `false` |  |
-| username | GitHub username for commits | `false` | github-actions |
-| email | GitHub email for commits | `false` | <github-actions@github.com> |
+| name       | description                            | required | default                     |
+|------------|----------------------------------------|----------|-----------------------------|
+| `token`    | <p>GitHub token for authentication</p> | `false`  | `""`                        |
+| `username` | <p>GitHub username for commits</p>     | `false`  | `github-actions`            |
+| `email`    | <p>GitHub email for commits</p>        | `false`  | `github-actions@github.com` |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| validation_status | Overall validation status (success/failure) |
-| errors_found | Number of linting errors found |
+| name                | description                                        |
+|---------------------|----------------------------------------------------|
+| `validation_status` | <p>Overall validation status (success/failure)</p> |
+| `errors_found`      | <p>Number of linting errors found</p>              |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/pr-lint@vYYYY.MM.DD
+  with:
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    username:
+    # GitHub username for commits
+    #
+    # Required: false
+    # Default: github-actions
+
+    email:
+    # GitHub email for commits
+    #
+    # Required: false
+    # Default: github-actions@github.com
+```

--- a/pr-lint/action.yml
+++ b/pr-lint/action.yml
@@ -338,7 +338,7 @@ runs:
 
     - name: Setup PHP
       if: steps.detect-php.outputs.found == 'true'
-      uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ steps.php-version.outputs.detected-version }}
         tools: composer

--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -6,21 +6,57 @@ Runs pre-commit on the repository and pushes the fixes back to the repository
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| pre-commit-config | pre-commit configuration file | `false` | .pre-commit-config.yaml |
-| base-branch | Base branch to compare against | `false` |  |
-| token | GitHub token for authentication | `false` |  |
-| commit_user | Commit user | `false` | GitHub Actions |
-| commit_email | Commit email | `false` | <github-actions@github.com> |
+| name                | description                            | required | default                     |
+|---------------------|----------------------------------------|----------|-----------------------------|
+| `pre-commit-config` | <p>pre-commit configuration file</p>   | `false`  | `.pre-commit-config.yaml`   |
+| `base-branch`       | <p>Base branch to compare against</p>  | `false`  | `""`                        |
+| `token`             | <p>GitHub token for authentication</p> | `false`  | `""`                        |
+| `commit_user`       | <p>Commit user</p>                     | `false`  | `GitHub Actions`            |
+| `commit_email`      | <p>Commit email</p>                    | `false`  | `github-actions@github.com` |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| hooks_passed | Whether all pre-commit hooks passed (true/false) |
-| files_changed | Whether any files were changed by pre-commit hooks |
+| name            | description                                               |
+|-----------------|-----------------------------------------------------------|
+| `hooks_passed`  | <p>Whether all pre-commit hooks passed (true/false)</p>   |
+| `files_changed` | <p>Whether any files were changed by pre-commit hooks</p> |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/pre-commit@vYYYY.MM.DD
+  with:
+    pre-commit-config:
+    # pre-commit configuration file
+    #
+    # Required: false
+    # Default: .pre-commit-config.yaml
+
+    base-branch:
+    # Base branch to compare against
+    #
+    # Required: false
+    # Default: ""
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    commit_user:
+    # Commit user
+    #
+    # Required: false
+    # Default: GitHub Actions
+
+    commit_email:
+    # Commit email
+    #
+    # Required: false
+    # Default: github-actions@github.com
+```

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -46,7 +46,10 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
-        persist-credentials: false
+        # git-auto-commit-action pushes the auto-fix commit using the token that
+        # actions/checkout persists in .git/config; persist-credentials must stay
+        # true or the "Commit Fixes" step cannot authenticate its push.
+        persist-credentials: true # zizmor: ignore[artipacked]
 
     - name: Validate Inputs
       shell: sh

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -46,6 +46,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Validate Inputs
       shell: sh

--- a/prettier-lint/README.md
+++ b/prettier-lint/README.md
@@ -6,33 +6,123 @@ Run Prettier in check or fix mode with advanced configuration and reporting
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| mode | Mode to run (check or fix) | `false` | check |
-| working-directory | Directory containing files to format | `false` | . |
-| prettier-version | Prettier version to use | `false` | latest |
-| config-file | Path to Prettier config file | `false` | .prettierrc |
-| ignore-file | Path to Prettier ignore file | `false` | .prettierignore |
-| file-pattern | Files to include (glob pattern) | `false` | **/*.{js,jsx,ts,tsx,css,scss,json,md,yaml,yml} |
-| cache | Enable Prettier caching | `false` | true |
-| fail-on-error | Fail workflow if issues are found (check mode only) | `false` | true |
-| report-format | Output format for check mode (json, sarif) | `false` | sarif |
-| max-retries | Maximum number of retry attempts | `false` | 3 |
-| plugins | Comma-separated list of Prettier plugins to install | `false` |  |
-| token | GitHub token for authentication | `false` |  |
-| username | GitHub username for commits (fix mode only) | `false` | github-actions |
-| email | GitHub email for commits (fix mode only) | `false` | <github-actions@github.com> |
+| name                | description                                                | required | default                                          |
+|---------------------|------------------------------------------------------------|----------|--------------------------------------------------|
+| `mode`              | <p>Mode to run (check or fix)</p>                          | `false`  | `check`                                          |
+| `working-directory` | <p>Directory containing files to format</p>                | `false`  | `.`                                              |
+| `prettier-version`  | <p>Prettier version to use</p>                             | `false`  | `latest`                                         |
+| `config-file`       | <p>Path to Prettier config file</p>                        | `false`  | `.prettierrc`                                    |
+| `ignore-file`       | <p>Path to Prettier ignore file</p>                        | `false`  | `.prettierignore`                                |
+| `file-pattern`      | <p>Files to include (glob pattern)</p>                     | `false`  | `**/*.{js,jsx,ts,tsx,css,scss,json,md,yaml,yml}` |
+| `cache`             | <p>Enable Prettier caching</p>                             | `false`  | `true`                                           |
+| `fail-on-error`     | <p>Fail workflow if issues are found (check mode only)</p> | `false`  | `true`                                           |
+| `report-format`     | <p>Output format for check mode (json, sarif)</p>          | `false`  | `sarif`                                          |
+| `max-retries`       | <p>Maximum number of retry attempts</p>                    | `false`  | `3`                                              |
+| `plugins`           | <p>Comma-separated list of Prettier plugins to install</p> | `false`  | `""`                                             |
+| `token`             | <p>GitHub token for authentication</p>                     | `false`  | `""`                                             |
+| `username`          | <p>GitHub username for commits (fix mode only)</p>         | `false`  | `github-actions`                                 |
+| `email`             | <p>GitHub email for commits (fix mode only)</p>            | `false`  | `github-actions@github.com`                      |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| status | Overall status (success/failure) |
-| files-checked | Number of files checked (check mode only) |
-| unformatted-files | Number of files with formatting issues (check mode only) |
-| sarif-file | Path to SARIF report file (check mode only) |
-| files-changed | Number of files changed (fix mode only) |
+| name                | description                                                     |
+|---------------------|-----------------------------------------------------------------|
+| `status`            | <p>Overall status (success/failure)</p>                         |
+| `files-checked`     | <p>Number of files checked (check mode only)</p>                |
+| `unformatted-files` | <p>Number of files with formatting issues (check mode only)</p> |
+| `sarif-file`        | <p>Path to SARIF report file (check mode only)</p>              |
+| `files-changed`     | <p>Number of files changed (fix mode only)</p>                  |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/prettier-lint@vYYYY.MM.DD
+  with:
+    mode:
+    # Mode to run (check or fix)
+    #
+    # Required: false
+    # Default: check
+
+    working-directory:
+    # Directory containing files to format
+    #
+    # Required: false
+    # Default: .
+
+    prettier-version:
+    # Prettier version to use
+    #
+    # Required: false
+    # Default: latest
+
+    config-file:
+    # Path to Prettier config file
+    #
+    # Required: false
+    # Default: .prettierrc
+
+    ignore-file:
+    # Path to Prettier ignore file
+    #
+    # Required: false
+    # Default: .prettierignore
+
+    file-pattern:
+    # Files to include (glob pattern)
+    #
+    # Required: false
+    # Default: **/*.{js,jsx,ts,tsx,css,scss,json,md,yaml,yml}
+
+    cache:
+    # Enable Prettier caching
+    #
+    # Required: false
+    # Default: true
+
+    fail-on-error:
+    # Fail workflow if issues are found (check mode only)
+    #
+    # Required: false
+    # Default: true
+
+    report-format:
+    # Output format for check mode (json, sarif)
+    #
+    # Required: false
+    # Default: sarif
+
+    max-retries:
+    # Maximum number of retry attempts
+    #
+    # Required: false
+    # Default: 3
+
+    plugins:
+    # Comma-separated list of Prettier plugins to install
+    #
+    # Required: false
+    # Default: ""
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    username:
+    # GitHub username for commits (fix mode only)
+    #
+    # Required: false
+    # Default: github-actions
+
+    email:
+    # GitHub email for commits (fix mode only)
+    #
+    # Required: false
+    # Default: github-actions@github.com
+```

--- a/prettier-lint/action.yml
+++ b/prettier-lint/action.yml
@@ -119,7 +119,10 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
-        persist-credentials: false
+        # git-auto-commit-action pushes the auto-fix commit using the token that
+        # actions/checkout persists in .git/config; persist-credentials must stay
+        # true or the "Commit Fixes" step cannot authenticate its push.
+        persist-credentials: true # zizmor: ignore[artipacked]
 
     - name: Detect Package Manager
       id: detect-pm

--- a/prettier-lint/action.yml
+++ b/prettier-lint/action.yml
@@ -119,6 +119,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Detect Package Manager
       id: detect-pm

--- a/python-lint-fix/README.md
+++ b/python-lint-fix/README.md
@@ -6,26 +6,86 @@ Lints and fixes Python files, commits changes, and uploads SARIF report.
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| python-version | Python version to use | `false` | 3.11 |
-| flake8-version | Flake8 version to use | `false` | 7.0.0 |
-| autopep8-version | Autopep8 version to use | `false` | 2.0.4 |
-| max-retries | Maximum number of retry attempts for installations and linting | `false` | 3 |
-| working-directory | Directory containing Python files to lint | `false` | . |
-| fail-on-error | Whether to fail the action if linting errors are found | `false` | true |
-| token | GitHub token for authentication | `false` |  |
-| username | GitHub username for commits | `false` | github-actions |
-| email | GitHub email for commits | `false` | <github-actions@github.com> |
+| name                | description                                                           | required | default                     |
+|---------------------|-----------------------------------------------------------------------|----------|-----------------------------|
+| `python-version`    | <p>Python version to use</p>                                          | `false`  | `3.11`                      |
+| `flake8-version`    | <p>Flake8 version to use</p>                                          | `false`  | `7.0.0`                     |
+| `autopep8-version`  | <p>Autopep8 version to use</p>                                        | `false`  | `2.0.4`                     |
+| `max-retries`       | <p>Maximum number of retry attempts for installations and linting</p> | `false`  | `3`                         |
+| `working-directory` | <p>Directory containing Python files to lint</p>                      | `false`  | `.`                         |
+| `fail-on-error`     | <p>Whether to fail the action if linting errors are found</p>         | `false`  | `true`                      |
+| `token`             | <p>GitHub token for authentication</p>                                | `false`  | `""`                        |
+| `username`          | <p>GitHub username for commits</p>                                    | `false`  | `github-actions`            |
+| `email`             | <p>GitHub email for commits</p>                                       | `false`  | `github-actions@github.com` |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| lint-result | Result of the linting process (success/failure) |
-| fixed-files | Number of files that were fixed |
-| error-count | Number of errors found |
+| name          | description                                            |
+|---------------|--------------------------------------------------------|
+| `lint-result` | <p>Result of the linting process (success/failure)</p> |
+| `fixed-files` | <p>Number of files that were fixed</p>                 |
+| `error-count` | <p>Number of errors found</p>                          |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/python-lint-fix@vYYYY.MM.DD
+  with:
+    python-version:
+    # Python version to use
+    #
+    # Required: false
+    # Default: 3.11
+
+    flake8-version:
+    # Flake8 version to use
+    #
+    # Required: false
+    # Default: 7.0.0
+
+    autopep8-version:
+    # Autopep8 version to use
+    #
+    # Required: false
+    # Default: 2.0.4
+
+    max-retries:
+    # Maximum number of retry attempts for installations and linting
+    #
+    # Required: false
+    # Default: 3
+
+    working-directory:
+    # Directory containing Python files to lint
+    #
+    # Required: false
+    # Default: .
+
+    fail-on-error:
+    # Whether to fail the action if linting errors are found
+    #
+    # Required: false
+    # Default: true
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    username:
+    # GitHub username for commits
+    #
+    # Required: false
+    # Default: github-actions
+
+    email:
+    # GitHub email for commits
+    #
+    # Required: false
+    # Default: github-actions@github.com
+```

--- a/python-lint-fix/action.yml
+++ b/python-lint-fix/action.yml
@@ -87,6 +87,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Detect Python Version
       id: python-version

--- a/python-lint-fix/action.yml
+++ b/python-lint-fix/action.yml
@@ -87,7 +87,10 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
-        persist-credentials: false
+        # git-auto-commit-action pushes the auto-fix commit using the token that
+        # actions/checkout persists in .git/config; persist-credentials must stay
+        # true or the "Commit Fixes" step cannot authenticate its push.
+        persist-credentials: true # zizmor: ignore[artipacked]
 
     - name: Detect Python Version
       id: python-version

--- a/release-monthly/README.md
+++ b/release-monthly/README.md
@@ -6,20 +6,44 @@ Creates a release for the current month, incrementing patch number if necessary.
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| token | GitHub token with permission to create releases. | `true` | ${{ github.token }} |
-| dry-run | Run in dry-run mode without creating the release. | `false` | false |
-| prefix | Optional prefix for release tags. | `false` |  |
+| name      | description                                              | required | default               |
+|-----------|----------------------------------------------------------|----------|-----------------------|
+| `token`   | <p>GitHub token with permission to create releases.</p>  | `true`   | `${{ github.token }}` |
+| `dry-run` | <p>Run in dry-run mode without creating the release.</p> | `false`  | `false`               |
+| `prefix`  | <p>Optional prefix for release tags.</p>                 | `false`  | `""`                  |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| release-tag | The tag of the created release |
-| release-url | The URL of the created release |
-| previous-tag | The previous release tag |
+| name           | description                           |
+|----------------|---------------------------------------|
+| `release-tag`  | <p>The tag of the created release</p> |
+| `release-url`  | <p>The URL of the created release</p> |
+| `previous-tag` | <p>The previous release tag</p>       |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/release-monthly@vYYYY.MM.DD
+  with:
+    token:
+    # GitHub token with permission to create releases.
+    #
+    # Required: true
+    # Default: ${{ github.token }}
+
+    dry-run:
+    # Run in dry-run mode without creating the release.
+    #
+    # Required: false
+    # Default: false
+
+    prefix:
+    # Optional prefix for release tags.
+    #
+    # Required: false
+    # Default: ""
+```

--- a/release-monthly/action.yml
+++ b/release-monthly/action.yml
@@ -67,6 +67,7 @@ runs:
       with:
         token: ${{ inputs.token }}
         fetch-depth: 0 # Fetch all history for tag comparison
+        persist-credentials: false
 
     # timeout-minutes is set at the calling workflow level
     - name: Create Release

--- a/security-scan/README.md
+++ b/security-scan/README.md
@@ -8,25 +8,73 @@ Gitleaks (optional), and Trivy vulnerability scanning. Requires
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| gitleaks-license | Gitleaks license key (required for Gitleaks scanning) | `false` |  |
-| gitleaks-config | Path to Gitleaks config file | `false` | .gitleaks.toml |
-| trivy-severity | Severity levels to scan for (comma-separated) | `false` | CRITICAL,HIGH |
-| trivy-scanners | Types of scanners to run (comma-separated) | `false` | vuln,config,secret |
-| trivy-timeout | Timeout for Trivy scan | `false` | 10m |
-| actionlint-enabled | Enable actionlint scanning | `false` | true |
-| token | GitHub token for authentication | `false` |  |
+| name                 | description                                                  | required | default              |
+|----------------------|--------------------------------------------------------------|----------|----------------------|
+| `gitleaks-license`   | <p>Gitleaks license key (required for Gitleaks scanning)</p> | `false`  | `""`                 |
+| `gitleaks-config`    | <p>Path to Gitleaks config file</p>                          | `false`  | `.gitleaks.toml`     |
+| `trivy-severity`     | <p>Severity levels to scan for (comma-separated)</p>         | `false`  | `CRITICAL,HIGH`      |
+| `trivy-scanners`     | <p>Types of scanners to run (comma-separated)</p>            | `false`  | `vuln,config,secret` |
+| `trivy-timeout`      | <p>Timeout for Trivy scan</p>                                | `false`  | `10m`                |
+| `actionlint-enabled` | <p>Enable actionlint scanning</p>                            | `false`  | `true`               |
+| `token`              | <p>GitHub token for authentication</p>                       | `false`  | `""`                 |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| has_trivy_results | Whether Trivy scan produced valid results |
-| has_gitleaks_results | Whether Gitleaks scan produced valid results |
-| total_issues | Total number of security issues found |
-| critical_issues | Number of critical security issues found |
+| name                   | description                                         |
+|------------------------|-----------------------------------------------------|
+| `has_trivy_results`    | <p>Whether Trivy scan produced valid results</p>    |
+| `has_gitleaks_results` | <p>Whether Gitleaks scan produced valid results</p> |
+| `total_issues`         | <p>Total number of security issues found</p>        |
+| `critical_issues`      | <p>Number of critical security issues found</p>     |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/security-scan@vYYYY.MM.DD
+  with:
+    gitleaks-license:
+    # Gitleaks license key (required for Gitleaks scanning)
+    #
+    # Required: false
+    # Default: ""
+
+    gitleaks-config:
+    # Path to Gitleaks config file
+    #
+    # Required: false
+    # Default: .gitleaks.toml
+
+    trivy-severity:
+    # Severity levels to scan for (comma-separated)
+    #
+    # Required: false
+    # Default: CRITICAL,HIGH
+
+    trivy-scanners:
+    # Types of scanners to run (comma-separated)
+    #
+    # Required: false
+    # Default: vuln,config,secret
+
+    trivy-timeout:
+    # Timeout for Trivy scan
+    #
+    # Required: false
+    # Default: 10m
+
+    actionlint-enabled:
+    # Enable actionlint scanning
+    #
+    # Required: false
+    # Default: true
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+```

--- a/security-scan/action.yml
+++ b/security-scan/action.yml
@@ -67,6 +67,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Validate Inputs
       shell: sh

--- a/stale/README.md
+++ b/stale/README.md
@@ -6,19 +6,43 @@ A GitHub Action to close stale issues and pull requests.
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| token | GitHub token for authentication | `false` |  |
-| days-before-stale | Number of days of inactivity before an issue is marked as stale | `false` | 30 |
-| days-before-close | Number of days of inactivity before a stale issue is closed | `false` | 7 |
+| name                | description                                                            | required | default |
+|---------------------|------------------------------------------------------------------------|----------|---------|
+| `token`             | <p>GitHub token for authentication</p>                                 | `false`  | `""`    |
+| `days-before-stale` | <p>Number of days of inactivity before an issue is marked as stale</p> | `false`  | `30`    |
+| `days-before-close` | <p>Number of days of inactivity before a stale issue is closed</p>     | `false`  | `7`     |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| staled_issues_count | Number of issues marked as stale |
-| closed_issues_count | Number of issues closed |
+| name                  | description                             |
+|-----------------------|-----------------------------------------|
+| `staled_issues_count` | <p>Number of issues marked as stale</p> |
+| `closed_issues_count` | <p>Number of issues closed</p>          |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/stale@vYYYY.MM.DD
+  with:
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    days-before-stale:
+    # Number of days of inactivity before an issue is marked as stale
+    #
+    # Required: false
+    # Default: 30
+
+    days-before-close:
+    # Number of days of inactivity before a stale issue is closed
+    #
+    # Required: false
+    # Default: 7
+```

--- a/stale/action.yml
+++ b/stale/action.yml
@@ -40,6 +40,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Validate Inputs
       shell: sh

--- a/sync-labels/README.md
+++ b/sync-labels/README.md
@@ -6,17 +6,35 @@ Sync labels from a YAML file to a GitHub repository
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| labels | Path to the labels YAML file | `false` |  |
-| token | GitHub token for authentication | `false` | ${{ github.token }} |
+| name     | description                            | required | default               |
+|----------|----------------------------------------|----------|-----------------------|
+| `labels` | <p>Path to the labels YAML file</p>    | `false`  | `""`                  |
+| `token`  | <p>GitHub token for authentication</p> | `false`  | `${{ github.token }}` |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| labels | Path to the labels YAML file |
+| name     | description                         |
+|----------|-------------------------------------|
+| `labels` | <p>Path to the labels YAML file</p> |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/sync-labels@vYYYY.MM.DD
+  with:
+    labels:
+    # Path to the labels YAML file
+    #
+    # Required: false
+    # Default: ""
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ${{ github.token }}
+```

--- a/terraform-lint-fix/README.md
+++ b/terraform-lint-fix/README.md
@@ -6,28 +6,100 @@ Lints and fixes Terraform files with advanced validation and security checks.
 
 ## Inputs
 
-| parameter | description | required | default |
-| --- | --- | --- | --- |
-| terraform-version | Terraform version to use | `false` | latest |
-| tflint-version | TFLint version to use | `false` | latest |
-| working-directory | Directory containing Terraform files | `false` | . |
-| config-file | Path to TFLint config file | `false` | .tflint.hcl |
-| fail-on-error | Fail workflow if issues are found | `false` | true |
-| auto-fix | Automatically fix issues when possible | `false` | true |
-| max-retries | Maximum number of retry attempts | `false` | 3 |
-| format | Output format (compact, json, checkstyle, junit, sarif) | `false` | sarif |
-| token | GitHub token for authentication | `false` |  |
-| username | GitHub username for commits | `false` | github-actions |
-| email | GitHub email for commits | `false` | <github-actions@github.com> |
+| name                | description                                                    | required | default                     |
+|---------------------|----------------------------------------------------------------|----------|-----------------------------|
+| `terraform-version` | <p>Terraform version to use</p>                                | `false`  | `latest`                    |
+| `tflint-version`    | <p>TFLint version to use</p>                                   | `false`  | `latest`                    |
+| `working-directory` | <p>Directory containing Terraform files</p>                    | `false`  | `.`                         |
+| `config-file`       | <p>Path to TFLint config file</p>                              | `false`  | `.tflint.hcl`               |
+| `fail-on-error`     | <p>Fail workflow if issues are found</p>                       | `false`  | `true`                      |
+| `auto-fix`          | <p>Automatically fix issues when possible</p>                  | `false`  | `true`                      |
+| `max-retries`       | <p>Maximum number of retry attempts</p>                        | `false`  | `3`                         |
+| `format`            | <p>Output format (compact, json, checkstyle, junit, sarif)</p> | `false`  | `sarif`                     |
+| `token`             | <p>GitHub token for authentication</p>                         | `false`  | `""`                        |
+| `username`          | <p>GitHub username for commits</p>                             | `false`  | `github-actions`            |
+| `email`             | <p>GitHub email for commits</p>                                | `false`  | `github-actions@github.com` |
 
 ## Outputs
 
-| parameter | description |
-| --- | --- |
-| error-count | Number of errors found |
-| fixed-count | Number of issues fixed |
-| sarif-file | Path to SARIF report file |
+| name          | description                      |
+|---------------|----------------------------------|
+| `error-count` | <p>Number of errors found</p>    |
+| `fixed-count` | <p>Number of issues fixed</p>    |
+| `sarif-file`  | <p>Path to SARIF report file</p> |
 
 ## Runs
 
 This action is a `composite` action.
+
+## Usage
+
+```yaml
+- uses: ivuorinen/actions/terraform-lint-fix@vYYYY.MM.DD
+  with:
+    terraform-version:
+    # Terraform version to use
+    #
+    # Required: false
+    # Default: latest
+
+    tflint-version:
+    # TFLint version to use
+    #
+    # Required: false
+    # Default: latest
+
+    working-directory:
+    # Directory containing Terraform files
+    #
+    # Required: false
+    # Default: .
+
+    config-file:
+    # Path to TFLint config file
+    #
+    # Required: false
+    # Default: .tflint.hcl
+
+    fail-on-error:
+    # Fail workflow if issues are found
+    #
+    # Required: false
+    # Default: true
+
+    auto-fix:
+    # Automatically fix issues when possible
+    #
+    # Required: false
+    # Default: true
+
+    max-retries:
+    # Maximum number of retry attempts
+    #
+    # Required: false
+    # Default: 3
+
+    format:
+    # Output format (compact, json, checkstyle, junit, sarif)
+    #
+    # Required: false
+    # Default: sarif
+
+    token:
+    # GitHub token for authentication
+    #
+    # Required: false
+    # Default: ""
+
+    username:
+    # GitHub username for commits
+    #
+    # Required: false
+    # Default: github-actions
+
+    email:
+    # GitHub email for commits
+    #
+    # Required: false
+    # Default: github-actions@github.com
+```

--- a/terraform-lint-fix/action.yml
+++ b/terraform-lint-fix/action.yml
@@ -75,6 +75,7 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
+        persist-credentials: false
 
     - name: Validate Inputs
       shell: sh
@@ -99,30 +100,14 @@ runs:
         fi
         python3 validate.py
 
-    - name: Write Inputs to Environment
-      # All inputs (including format and fail-on-error) are validated by the
-      # "Validate Inputs" step above before they are written to the environment.
-      shell: sh
-      env:
-        INPUT_WORKING_DIR: ${{ inputs.working-directory }}
-        INPUT_CONFIG: ${{ inputs.config-file }}
-        INPUT_FORMAT: ${{ inputs.format }}
-        INPUT_FAIL: ${{ inputs.fail-on-error }}
-        INPUT_RETRIES: ${{ inputs.max-retries }}
-      run: |
-        set -eu
-        # Write validated inputs to GITHUB_ENV with a random delimiter to prevent heredoc injection
-        _dl=$(od -vAn -N8 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')
-        [ -n "$_dl" ] || _dl="$(printf 'EOF%s' "$$")"
-        printf 'VALIDATED_WORKING_DIR<<%s\n%s\n%s\n' "$_dl" "$INPUT_WORKING_DIR" "$_dl" >> "$GITHUB_ENV"
-        printf 'VALIDATED_CONFIG<<%s\n%s\n%s\n' "$_dl" "$INPUT_CONFIG" "$_dl" >> "$GITHUB_ENV"
-        printf 'VALIDATED_FORMAT<<%s\n%s\n%s\n' "$_dl" "$INPUT_FORMAT" "$_dl" >> "$GITHUB_ENV"
-        printf 'VALIDATED_FAIL<<%s\n%s\n%s\n' "$_dl" "$INPUT_FAIL" "$_dl" >> "$GITHUB_ENV"
-        printf 'VALIDATED_RETRIES<<%s\n%s\n%s\n' "$_dl" "$INPUT_RETRIES" "$_dl" >> "$GITHUB_ENV"
-
     - name: Check for Terraform Files
       id: check-files
       shell: sh
+      # Inputs are gated by the "Validate Inputs" step above, which fails the
+      # action on invalid input before this step runs; passing them through an
+      # env: block (never inline in run:) keeps the values injection-safe.
+      env:
+        VALIDATED_WORKING_DIR: ${{ inputs.working-directory }}
       run: |
         set -eu
         # Use validated environment variable
@@ -176,6 +161,8 @@ runs:
     - name: Configure TFLint
       if: steps.check-files.outputs.found == 'true'
       shell: sh
+      env:
+        VALIDATED_CONFIG: ${{ inputs.config-file }}
       run: |
         set -eu
         # Use validated environment variable
@@ -205,6 +192,11 @@ runs:
       if: steps.check-files.outputs.found == 'true'
       id: lint
       shell: sh
+      env:
+        VALIDATED_WORKING_DIR: ${{ inputs.working-directory }}
+        VALIDATED_CONFIG: ${{ inputs.config-file }}
+        VALIDATED_FORMAT: ${{ inputs.format }}
+        VALIDATED_FAIL: ${{ inputs.fail-on-error }}
       run: |
         set -eu
         # Use validated environment variables
@@ -239,6 +231,8 @@ runs:
       if: steps.check-files.outputs.found == 'true' && inputs.auto-fix == 'true'
       id: fix
       shell: sh
+      env:
+        VALIDATED_WORKING_DIR: ${{ inputs.working-directory }}
       run: |
         set -eu
         # Use validated environment variable

--- a/terraform-lint-fix/action.yml
+++ b/terraform-lint-fix/action.yml
@@ -75,7 +75,10 @@ runs:
       uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e # v6-beta
       with:
         token: ${{ inputs.token || github.token }}
-        persist-credentials: false
+        # git-auto-commit-action pushes the auto-fix commit using the token that
+        # actions/checkout persists in .git/config; persist-credentials must stay
+        # true or the "Commit Fixes" step cannot authenticate its push.
+        persist-credentials: true # zizmor: ignore[artipacked]
 
     - name: Validate Inputs
       shell: sh


### PR DESCRIPTION
## Summary

Resolves all `zizmor` findings across workflows and actions, hardens the release/CI tooling, and brings the docs pipeline and pre-commit gate into a working, reproducible state. All changes verified: `zizmor` reports 0 findings, `pre-commit run --all-files` passes, and the pre-PR `/pin-check` and `/security-audit` gates both pass (0 Critical/High/Medium).

## Changes (by commit)

- **chore(security): persist-credentials hardening** — `persist-credentials: false` on every `actions/checkout` across composite actions and workflows (branch work).
- **fix(ci): resolve zizmor security findings**
  - `security-suite`: replace the **archived** `semgrep/semgrep-action` with the **Opengrep** CLI — installed from the pinned `v1.22.0` release binary and **verified by SHA-256** before execution; dropped the now-unused `SEMGREP_APP_TOKEN`.
  - `release`: replace `softprops/action-gh-release` with `gh release create "$TAG" --verify-tag --generate-notes` (removes a third-party action).
  - `pr-lint`: fix github-script **template-injection** by passing the value through an `env:` block.
  - `terraform-lint-fix`: replace `GITHUB_ENV` writes with per-step `env:` blocks (removes cross-step env-injection surface + dead `VALIDATED_RETRIES`).
  - `csharp-publish`: `echo "::add-mask::"` → `printf` (consistent + safe).
  - `SECURITY.md`: document Opengrep, drop the `SEMGREP_APP_TOKEN` row.
- **build(docs): self-formatting docs target + drift gate** — `make docs` now formats each generated README in place (prettier → markdown-table-formatter, matching `make all`); new `docs-check.yml` workflow regenerates the action READMEs with pinned tooling and fails the PR on drift.
- **docs: regenerate action READMEs** — 25 READMEs rebuilt with the pinned `action-docs` (2.5.1) in canonical format.
- **style: canonical markdown formatting** — repo-wide table/format normalization + refreshed catalog (`make all`).
- **ci(pre-commit): fix the dead `generate-docs-format-lint` hook** — `types:` (an impossible AND) → `types_or:` so it actually runs, and entry `make all` → `make docs format lint` to avoid infinite recursion (`make all`'s `precommit` step re-invokes pre-commit).

## Verification

- `zizmor .github/workflows/* */action.yml` → **No findings** (52 suppressed).
- `pre-commit run --all-files` → **exit 0**, 0 files modified.
- `/pin-check` → **PASS** (all refs 40-char SHA-pinned, consistent).
- `/security-audit` → **PASS** (0 Critical/High/Medium; net security-positive).
- `make all` → exit 0, byte-stable/idempotent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Docs Drift Check workflow to automatically detect README/action documentation changes.

* **Bug Fixes & Security**
  * Improved CI/CD security by disabling Git credential persistence after repository checkout across multiple workflows.
  * Switched static security scanning from Semgrep to Opengrep and updated related reporting/configuration.
  * Updated release automation to create releases via the `gh` CLI.

* **Documentation**
  * Re-generated/standardized action catalog and per-action README tables, defaults, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->