### PR TITLE
chore(deps): update external action SHA pins

### DIFF
--- a/.github/actions/setup-test-environment/action.yml
+++ b/.github/actions/setup-test-environment/action.yml
@@ -22,7 +22,7 @@ runs:
         enable-cache: true
 
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version-file: pyproject.toml
 

--- a/.github/workflows/issue-stats.yml
+++ b/.github/workflows/issue-stats.yml
@@ -35,7 +35,7 @@ jobs:
           printf 'last_month=%04d-%02d\n' "$prev_year" "$prev_month" >> "$GITHUB_ENV"
 
       - name: Run issue-metrics tool
-        uses: github/issue-metrics@1e38d5e62363e14db8019ed7d106b9855bdba6cc # v4.2.7
+        uses: github/issue-metrics@44173f9e0a3b2144a777a10a340e4c09a25ac9f8 # v4.2.8
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEARCH_QUERY: 'repo:ivuorinen/actions is:issue created:${{ env.last_month }} -reason:"not planned"'

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -99,7 +99,7 @@ jobs:
           set -eu
           git archive --format=tar.gz --prefix="${TAG}/" HEAD > "${TAG}-source.tar.gz"
           sha256sum "${TAG}-source.tar.gz" > "${TAG}-source.tar.gz.sha256"
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: '${{ needs.new-daily-release.outputs.version }}-source.tar.gz'
       - name: Upload release assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           set -eu
           git archive --format=tar.gz --prefix="${TAG}/" HEAD > "${TAG}-source.tar.gz"
           sha256sum "${TAG}-source.tar.gz" > "${TAG}-source.tar.gz.sha256"
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: '${{ github.ref_name }}-source.tar.gz'
       - name: Upload release assets

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -62,7 +62,7 @@ jobs:
         # Only run on pull_request, not pull_request_target to prevent executing
         # untrusted third-party actions against PR head from forks
         if: github.event_name == 'pull_request'
-        uses: dependency-check/Dependency-Check_Action@3102a65fd5f36d0000297576acc56a475b0de98d # main
+        uses: dependency-check/Dependency-Check_Action@75ba02d6183445fe0761d26e836bde58b1560600 # 1.1.0
         with:
           project: 'PR Security Analysis'
           path: '.'

--- a/.github/workflows/security-suite.yml
+++ b/.github/workflows/security-suite.yml
@@ -92,7 +92,7 @@ jobs:
         continue-on-error: true
 
       - name: TruffleHog Secret Scan
-        uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
+        uses: trufflesecurity/trufflehog@30d5bb91af1a771378349dbbb0c82129392acf70 # v3.95.6
         with:
           path: ./
           base: ${{ env.BASE_REF }}

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -255,7 +255,7 @@ jobs:
           install-kcov: 'true'
 
       - name: Scan for secrets
-        uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
+        uses: trufflesecurity/trufflehog@30d5bb91af1a771378349dbbb0c82129392acf70 # v3.95.6
         with:
           path: ./
           base: ${{ github.event_name == 'pull_request' && github.event.repository.default_branch || '' }}

--- a/ansible-lint-fix/action.yml
+++ b/ansible-lint-fix/action.yml
@@ -102,7 +102,7 @@ runs:
 
     - name: Setup Python
       if: steps.check-files.outputs.files_found == 'true'
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.14'
         cache: 'pip'

--- a/csharp-build/action.yml
+++ b/csharp-build/action.yml
@@ -164,7 +164,7 @@ runs:
         echo "Final detected .NET version: $detected_version" >&2
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: ${{ steps.detect-dotnet-version.outputs.detected-version }}
         cache: true

--- a/csharp-lint-check/action.yml
+++ b/csharp-lint-check/action.yml
@@ -154,7 +154,7 @@ runs:
         echo "Final detected .NET version: $detected_version" >&2
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: ${{ steps.detect-dotnet-version.outputs.detected-version }}
         cache: true

--- a/csharp-publish/action.yml
+++ b/csharp-publish/action.yml
@@ -171,7 +171,7 @@ runs:
         echo "Final detected .NET version: $detected_version" >&2
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: ${{ inputs.dotnet-version || steps.detect-dotnet-version.outputs.detected-version }}
         cache: true

--- a/go-build/action.yml
+++ b/go-build/action.yml
@@ -176,7 +176,7 @@ runs:
         echo "Final detected Go version: $detected_version" >&2
 
     - name: Setup Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ steps.detect-go-version.outputs.detected-version }}
         cache: true

--- a/go-lint/action.yml
+++ b/go-lint/action.yml
@@ -111,7 +111,7 @@ runs:
         python3 validate.py
 
     - name: Setup Go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ inputs.go-version }}
         cache: true

--- a/pr-lint/action.yml
+++ b/pr-lint/action.yml
@@ -489,7 +489,7 @@ runs:
 
     - name: Setup Python
       if: steps.detect-python.outputs.found == 'true'
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ steps.python-version.outputs.detected-version }}
         cache: 'pip'

--- a/pr-lint/action.yml
+++ b/pr-lint/action.yml
@@ -624,7 +624,7 @@ runs:
 
     - name: Setup Go
       if: steps.detect-go.outputs.found == 'true'
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: ${{ steps.go-version.outputs.detected-version }}
         cache: true

--- a/python-lint-fix/action.yml
+++ b/python-lint-fix/action.yml
@@ -234,7 +234,7 @@ runs:
 
     - name: Setup Python (pip)
       if: steps.package-manager.outputs.package-manager == 'pip'
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ steps.python-version.outputs.detected-version }}
         cache: 'pip'
@@ -247,7 +247,7 @@ runs:
 
     - name: Setup Python (pipenv)
       if: steps.package-manager.outputs.package-manager == 'pipenv'
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ steps.python-version.outputs.detected-version }}
         cache: 'pipenv'
@@ -257,7 +257,7 @@ runs:
 
     - name: Setup Python (poetry)
       if: steps.package-manager.outputs.package-manager == 'poetry'
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ steps.python-version.outputs.detected-version }}
         cache: 'poetry'

--- a/security-scan/action.yml
+++ b/security-scan/action.yml
@@ -115,7 +115,7 @@ runs:
 
     - name: Run actionlint
       if: steps.check-configs.outputs.run_actionlint == 'true'
-      uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+      uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
       with:
         cache: true
         fail-on-error: true


### PR DESCRIPTION
## Summary

External GitHub Action SHA-pin upgrades, committed one dependency per commit.

| Dependency                                 | Change                                                            |
| ------------------------------------------ | ----------------------------------------------------------------- |
| `actions/setup-python`                     | v6.2.0 → v6.3.0                                                   |
| `actions/setup-go`                         | v6.4.0 → v6.5.0                                                   |
| `actions/setup-dotnet`                     | v5.3.0 → v5.4.0                                                   |
| `actions/attest-build-provenance`          | v4.1.0 → v4.1.1                                                   |
| `trufflesecurity/trufflehog`               | v3.95.5 → v3.95.6                                                 |
| `github/issue-metrics`                     | v4.2.7 → v4.2.8                                                   |
| `raven-actions/actionlint`                 | v2.1.2 → v2.2.0                                                   |
| `dependency-check/Dependency-Check_Action` | `main` → `1.1.0` (pinned to a release instead of tracking `main`) |

All references remain SHA-pinned with version comments. `pr-lint` and `security-suite` were split by hunk so each commit contains exactly one dependency.

## Notes

- The `dependency-check/Dependency-Check_Action` pin previously tracked the head of `main`; it now points at the SHA behind the latest release tag `1.1.0` (`75ba02d6183445fe0761d26e836bde58b1560600`).
- Pre-commit hooks (actionlint, action-validator, yamllint) passed on every commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several automation and CI environment tools to newer versions across build, lint, release, and security workflows.
  * Refreshed secret scanning, dependency checking, and action linting components.
  * Brought Python, Go, .NET, and related setup steps up to date for more consistent and reliable pipeline runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->