### PR TITLE
chore(deps): update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         types_or: [markdown, python, yaml]
         files: ^(docs/.*|README\.md|CONTRIBUTING\.md|CHANGELOG\.md|.*\.py|.*\.ya?ml)$
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.21
+    rev: 0.11.25
     hooks:
       - id: uv-lock
       - id: uv-sync
@@ -58,7 +58,7 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.17
+    rev: v0.15.20
     hooks:
       # Run the linter with auto-fix
       - id: ruff-check
@@ -87,7 +87,7 @@ repos:
         args: ['-shellcheck=']
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: '3.3.1'
+    rev: '3.3.2'
     hooks:
       - id: checkov
         args:


### PR DESCRIPTION
## Summary

Routine pre-commit hook version bumps (via `pre-commit autoupdate`).

| Hook | From | To |
|------|------|----|
| `astral-sh/uv-pre-commit` | 0.11.21 | 0.11.25 |
| `astral-sh/ruff-pre-commit` | v0.15.17 | v0.15.20 |
| `bridgecrewio/checkov` | 3.3.1 | 3.3.2 |

## Checks

- `/nitpicker` (changed-files): no findings — three `rev:` tag bumps only.
- `/pin-check`: PASS — all `action.yml` external refs remain SHA-pinned.
- `/security-audit`: no security surface — diff touches only `.pre-commit-config.yaml`.
- Local pre-commit run on commit: all hooks Passed.