### PR TITLE
feat(sync-labels): treat missing manifest as warning + successful no-op

### DIFF
--- a/_tests/unit/sync-labels/sync.spec.sh
+++ b/_tests/unit/sync-labels/sync.spec.sh
@@ -192,9 +192,23 @@ The status should be failure
 The error should include "invalid repository"
 End
 
-It "fails clearly when the manifest is missing"
+It "warns and succeeds as a no-op when the manifest is missing"
 export INPUT_LABELS=".github/missing.yml"
 When call run_sync
+The status should be success
+The output should include '::warning::sync-labels: manifest not found: ".github/missing.yml"'
+The contents of file "$GITHUB_OUTPUT" should include "created=0"
+The contents of file "$GITHUB_OUTPUT" should include "updated=0"
+The contents of file "$GITHUB_OUTPUT" should include "deleted=0"
+The contents of file "$GITHUB_OUTPUT" should include "unchanged=0"
+The contents of file "$GITHUB_OUTPUT" should include "repositories=0"
+The contents of file "$GH_CALL_LOG" should be blank
+End
+
+# main() short-circuits before load_manifest; this covers the function's own
+# guard (TOCTOU window / direct callers) which is otherwise unreachable.
+It "load_manifest itself still rejects a missing path"
+When call python3 -c "import sys; sys.path.insert(0, '${PROJECT_ROOT}/sync-labels'); import sync; sync.load_manifest('.github/nope.yml')"
 The status should be failure
 The error should include "manifest not found"
 End

--- a/sync-labels/README.md
+++ b/sync-labels/README.md
@@ -6,12 +6,12 @@ Sync GitHub labels declaratively from a YAML/JSON manifest (no Docker)
 
 ## Inputs
 
-| name         | description                                                                                                                                                                  | required | default               |
-|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------|
-| `labels`     | <p>Path to the labels manifest (YAML or JSON), relative to the repository root. Defaults to .github/labels.yml when omitted (no longer the action's bundled labels.yml).</p> | `false`  | `""`                  |
-| `repository` | <p>Newline-separated list of owner/repo targets. Defaults to the current repository. Cross-repo sync requires a PAT in the token input.</p>                                  | `false`  | `""`                  |
-| `prune`      | <p>Delete existing labels that are not listed in the manifest</p>                                                                                                            | `false`  | `true`                |
-| `token`      | <p>GitHub token for authentication (use a PAT for cross-repo sync)</p>                                                                                                       | `false`  | `${{ github.token }}` |
+| name         | description                                                                                                                                                                                                                                    | required | default               |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------------|
+| `labels`     | <p>Path to the labels manifest (YAML or JSON), relative to the repository root. Defaults to .github/labels.yml when omitted (no longer the action's bundled labels.yml). A missing manifest is a warning + successful no-op, not an error.</p> | `false`  | `""`                  |
+| `repository` | <p>Newline-separated list of owner/repo targets. Defaults to the current repository. Cross-repo sync requires a PAT in the token input.</p>                                                                                                    | `false`  | `""`                  |
+| `prune`      | <p>Delete existing labels that are not listed in the manifest</p>                                                                                                                                                                              | `false`  | `true`                |
+| `token`      | <p>GitHub token for authentication (use a PAT for cross-repo sync)</p>                                                                                                                                                                         | `false`  | `${{ github.token }}` |
 
 ## Outputs
 
@@ -33,7 +33,7 @@ This action is a `composite` action.
 - uses: ivuorinen/actions/sync-labels@vYYYY.MM.DD
   with:
     labels:
-    # Path to the labels manifest (YAML or JSON), relative to the repository root. Defaults to .github/labels.yml when omitted (no longer the action's bundled labels.yml).
+    # Path to the labels manifest (YAML or JSON), relative to the repository root. Defaults to .github/labels.yml when omitted (no longer the action's bundled labels.yml). A missing manifest is a warning + successful no-op, not an error.
     #
     # Required: false
     # Default: ""

--- a/sync-labels/action.yml
+++ b/sync-labels/action.yml
@@ -12,7 +12,7 @@ branding:
 
 inputs:
   labels:
-    description: "Path to the labels manifest (YAML or JSON), relative to the repository root. Defaults to .github/labels.yml when omitted (no longer the action's bundled labels.yml)."
+    description: "Path to the labels manifest (YAML or JSON), relative to the repository root. Defaults to .github/labels.yml when omitted (no longer the action's bundled labels.yml). A missing manifest is a warning + successful no-op, not an error."
     required: false
     default: ''
   repository:

--- a/sync-labels/sync.py
+++ b/sync-labels/sync.py
@@ -16,7 +16,8 @@ Design notes
   zero requests.
 
 Inputs (read from ``INPUT_*`` env vars, set by action.yml):
-  INPUT_LABELS      manifest path (default ``.github/labels.yml``)
+  INPUT_LABELS      manifest path (default ``.github/labels.yml``); a missing
+                    manifest is a warning + successful no-op, not an error
   INPUT_REPOSITORY  newline-separated ``owner/repo`` list (default: current repo)
   INPUT_PRUNE       ``true``/``false`` — delete labels not in the manifest (default true)
 
@@ -74,6 +75,8 @@ def _run(argv: list[str]) -> str:
 def load_manifest(path: str) -> list[dict]:
     """Load the manifest as a list of dicts. YAML via ``yq``, JSON via stdlib."""
     if not Path(path).is_file():
+        # main() already skips a missing manifest with a warning; this guards the
+        # TOCTOU window and direct callers with a clear error instead of yq noise.
         fail(f'manifest not found: "{path}"')
     if shutil.which("yq"):
         raw = _run(["yq", "-o=json", "-I=0", ".", path])
@@ -235,14 +238,33 @@ def resolve_repos() -> list[str]:
     return repos
 
 
+def write_outputs(totals: dict[str, int], repo_count: int) -> None:
+    """Append the action's outputs to GITHUB_OUTPUT (no-op outside Actions)."""
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    with Path(output).open("a", encoding="utf-8") as handle:
+        handle.write(f"created={totals['created']}\n")
+        handle.write(f"updated={totals['updated']}\n")
+        handle.write(f"deleted={totals['deleted']}\n")
+        handle.write(f"unchanged={totals['unchanged']}\n")
+        handle.write(f"repositories={repo_count}\n")
+
+
 def main() -> int:
     """Entry point: load the manifest and reconcile every target repository."""
     manifest = os.environ.get("INPUT_LABELS", "").strip() or DEFAULT_MANIFEST
+    totals = {"created": 0, "updated": 0, "deleted": 0, "unchanged": 0}
+    if not Path(manifest).is_file():
+        # A repo without a manifest has nothing to sync — warn and succeed so the
+        # action can run unconditionally across repos that opt in by adding one.
+        print(f'::warning::sync-labels: manifest not found: "{manifest}" — nothing to sync')
+        write_outputs(totals, 0)
+        return 0
     prune = _bool(os.environ.get("INPUT_PRUNE", ""), default=True)
     desired = normalize(load_manifest(manifest))
     repos = resolve_repos()
 
-    totals = {"created": 0, "updated": 0, "deleted": 0, "unchanged": 0}
     for repo in repos:
         print(f"Syncing {len(desired)} labels to {repo} (prune={'true' if prune else 'false'})")
         for key, value in sync_repo(repo, desired, prune=prune).items():
@@ -255,14 +277,7 @@ def main() -> int:
     )
     print(f"::notice::sync-labels: {summary}")
 
-    output = os.environ.get("GITHUB_OUTPUT")
-    if output:
-        with Path(output).open("a", encoding="utf-8") as handle:
-            handle.write(f"created={totals['created']}\n")
-            handle.write(f"updated={totals['updated']}\n")
-            handle.write(f"deleted={totals['deleted']}\n")
-            handle.write(f"unchanged={totals['unchanged']}\n")
-            handle.write(f"repositories={len(repos)}\n")
+    write_outputs(totals, len(repos))
     return 0
 
 


### PR DESCRIPTION
## Summary

A missing labels manifest (default `.github/labels.yml`) no longer fails the job. `sync.py:main()` now checks the resolved manifest path as its first step and, when the file is absent:

- emits `::warning::sync-labels: manifest not found: "<path>" — nothing to sync`
- writes zeroed outputs (`created`/`updated`/`deleted`/`unchanged`=0, `repositories`=0) so `steps.<id>.outputs.*` consumers keep working
- exits 0 before any token/repo/`gh` work

The output-writing block is extracted into a shared `write_outputs()`. `load_manifest()` keeps its own not-found error as a TOCTOU/direct-caller guard, now covered by a dedicated test.

> [!WARNING]
> **Breaking behavior change**: a missing manifest previously failed with `::error::manifest not found`; it now succeeds with a warning. Strict callers can assert `steps.<id>.outputs.repositories != '0'`.

## Changes

- `sync-labels/sync.py` — early missing-manifest guard + `write_outputs()` extraction
- `sync-labels/action.yml` + regenerated `README.md` — `labels` input description documents the warn-and-succeed behavior
- `_tests/unit/sync-labels/sync.spec.sh` — missing-manifest spec now asserts success/warning/zeroed outputs/zero `gh` calls; new spec covers `load_manifest`'s own guard

## Verification

- `make test-action ACTION=sync-labels` — all unit tests pass (incl. 2 new/updated specs)
- `make lint` — clean; `ruff check` + format clean
- `/action-health sync-labels` — all PASS (action-validator, validate.py current, README current, `set -eu`, no output-format violations; SHA-pin N/A, no `uses:` refs)
- `/pin-check` + `/security-audit` — no findings against this change (1 LOW advisory: fail-open is the intended design; detectable via the warning and `repositories=0`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing label manifest files now trigger a warning and a successful no-op instead of a failure.
  * Output values are now reported consistently, including zero changes when no manifest is found.

* **Documentation**
  * Clarified the labels input behavior and default manifest path.
  * Updated usage notes to reflect the new missing-manifest behavior.

* **Tests**
  * Updated unit coverage for missing manifest handling and direct manifest loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->